### PR TITLE
fix: permission gate catches chained/wrapped dangerous commands, add project boundary (0.1.3)

### DIFF
--- a/packages/backend/src/index.ts
+++ b/packages/backend/src/index.ts
@@ -1,9 +1,12 @@
 export { createLogger, initLogging, type Logger } from "./log";
-export { makePermissionGateExtension } from "./permission-extension";
+export { makePermissionGateExtension, type PermissionGateOptions } from "./permission-extension";
 export {
 	createPermissionConfigLoader,
 	DEFAULT_PERMISSION_CONFIG,
+	evaluateBashCommand,
 	evaluateRules,
+	extractShellExecArg,
+	extractSubstitutions,
 	loadPermissionConfig,
 	matchPattern,
 	matchTextFor,
@@ -12,7 +15,9 @@ export {
 	type PermissionConfig,
 	type PermissionRule,
 	type PermissionRules,
+	permissionConfigPath,
 	setPermissionEnabled,
+	splitShellSegments,
 	suggestPattern,
 } from "./permission-rules";
 export { PermissionGate, type PermissionResponder } from "./permissions";

--- a/packages/backend/src/permission-extension.ts
+++ b/packages/backend/src/permission-extension.ts
@@ -1,21 +1,37 @@
+import { isAbsolute, relative, resolve } from "node:path";
 import type { InlineExtension } from "@earendil-works/pi-coding-agent";
 import { createLogger } from "./log";
 import {
 	createPermissionConfigLoader,
+	evaluateBashCommand,
 	evaluateRules,
 	matchTextFor,
+	type PermissionAction,
 	suggestPattern,
 } from "./permission-rules";
 
 const log = createLogger("permission-gate");
+
+/** matchText 为文件路径的工具（项目边界检查对象；grep/find 的 matchText 是 pattern 不在列） */
+const PATH_TOOLS = new Set(["read", "edit", "write", "ls"]);
+
+export interface PermissionGateOptions {
+	/** 会话项目根：带路径工具解析后落在根外时，规则结果为 allow 也提升为 ask */
+	projectRoot?: string;
+}
 
 /**
  * 内置权限门控扩展：只用 pi 公开扩展 API（tool_call 钩子 + ctx.ui.confirm），
  * 与用户可自行安装的权限扩展能力完全等同——可作为用户替代品的参考实现。
  * 规则配置 ~/.pi/agent/permissions.json（mtime 检查，修改即时生效）；
  * enabled=false 时整体放行（用户换用自己的扩展时关闭本扩展）。
+ * 边界检查只覆盖路径工具：bash 无法用路径模式约束（cd 任意跳），符号链接逃逸不在范围。
  */
-export function makePermissionGateExtension(agentDir: string): InlineExtension {
+export function makePermissionGateExtension(
+	agentDir: string,
+	options?: PermissionGateOptions,
+): InlineExtension {
+	const projectRoot = options?.projectRoot ? resolve(options.projectRoot) : null;
 	return {
 		name: "permission-gate",
 		factory: (pi) => {
@@ -25,7 +41,20 @@ export function makePermissionGateExtension(agentDir: string): InlineExtension {
 				if (!config.enabled) return;
 				const input = (event.input ?? {}) as Record<string, unknown>;
 				const matchText = matchTextFor(event.toolName, input);
-				const action = evaluateRules(config.rules, event.toolName, matchText);
+				// bash 单次求值同时拿到命中段（弹窗标题定位用）
+				const bashResult =
+					event.toolName === "bash" && matchText ? evaluateBashCommand(config.rules, matchText) : null;
+				let action: PermissionAction = bashResult
+					? bashResult.action
+					: evaluateRules(config.rules, event.toolName, matchText);
+				// 项目边界：路径工具落在根外时至少 ask（相对路径按 projectRoot resolve，可抓 ../../ 逃逸）
+				if (action === "allow" && projectRoot && matchText && PATH_TOOLS.has(event.toolName)) {
+					const abs = isAbsolute(matchText) ? matchText : resolve(projectRoot, matchText);
+					const rel = relative(projectRoot, abs);
+					if (rel.startsWith("..") || isAbsolute(rel)) {
+						action = "ask";
+					}
+				}
 				if (action === "allow") return;
 				if (action === "deny") {
 					log.info("tool blocked by rule", event.toolName, { matchText });
@@ -34,7 +63,11 @@ export function makePermissionGateExtension(agentDir: string): InlineExtension {
 						reason: `Blocked by permission rule (${event.toolName}). The user can change this in permissions.json.`,
 					};
 				}
-				const title = suggestPattern(event.toolName, input);
+				// 标题用命令链中命中危险动作的段（allowAlways 按标题记忆 = 会话白名单，
+				// 直接拿整串会导致 cd* 之类前缀入白名单，后续链式命令被误放行）
+				const title = bashResult
+					? suggestPattern("bash", { command: bashResult.segment })
+					: suggestPattern(event.toolName, input);
 				const detail = matchText ?? JSON.stringify(input).slice(0, 500);
 				let allowed = false;
 				try {

--- a/packages/backend/src/permission-rules.ts
+++ b/packages/backend/src/permission-rules.ts
@@ -68,15 +68,18 @@ export function matchPattern(pattern: string, text: string): boolean {
 	return new RegExp(`^${regex}$`).test(text);
 }
 
+/** 动作严格度：deny > ask > allow（命令链任一段取最严，危险命令无法藏在链里） */
+const ACTION_PRIORITY: Record<PermissionAction, number> = { allow: 0, ask: 1, deny: 2 };
+
 /**
- * 规则求值：默认值 → "*" 全局动作 → 工具动作 → 工具模式表（后命中覆盖）。
+ * 单段求值：默认值 → "*" 全局动作 → 工具动作 → 工具模式表（后命中覆盖）。
  * matchText 为 null（自定义工具无结构化匹配文本）时只吃工具名级动作与全局兜底。
  */
-export function evaluateRules(
+function evaluateSingle(
 	rules: PermissionRules,
 	toolName: string,
 	matchText: string | null,
-	fallback: PermissionAction = "ask",
+	fallback: PermissionAction,
 ): PermissionAction {
 	let action = fallback;
 	const globalRule = rules["*"];
@@ -96,6 +99,239 @@ export function evaluateRules(
 		}
 	}
 	return action;
+}
+
+/**
+ * bash 命令链切段：引号感知扫描，&& || & | ; 与换行仅在引号外分隔，去空段。
+ * 引号内不执行分隔符（`echo "a && rm -rf x"` 不误切）；`2>&1` 的 `>&`/`<&` 不算分隔。
+ */
+export function splitShellSegments(command: string): string[] {
+	const segments: string[] = [];
+	let current = "";
+	let quote: string | null = null;
+	let escaped = false;
+	const push = () => {
+		const trimmed = current.trim();
+		if (trimmed.length > 0) segments.push(trimmed);
+		current = "";
+	};
+	for (let i = 0; i < command.length; i++) {
+		const ch = command[i];
+		if (escaped) {
+			current += ch;
+			escaped = false;
+			continue;
+		}
+		if (ch === "\\" && quote !== "'") {
+			current += ch;
+			escaped = true;
+			continue;
+		}
+		if (quote) {
+			current += ch;
+			if (ch === quote) quote = null;
+			continue;
+		}
+		if (ch === "'" || ch === '"') {
+			current += ch;
+			quote = ch;
+			continue;
+		}
+		if (ch === "&" || ch === "|") {
+			const prev = current.trimEnd();
+			// 重定向复制 fd（2>&1、<&0）不是命令分隔
+			if (ch === "&" && (prev.endsWith(">") || prev.endsWith("<"))) {
+				current += ch;
+				continue;
+			}
+			if (command[i + 1] === ch) i++;
+			push();
+			continue;
+		}
+		if (ch === ";" || ch === "\n" || ch === "\r") {
+			push();
+			continue;
+		}
+		current += ch;
+	}
+	push();
+	return segments;
+}
+
+/**
+ * 提取顶层命令替换内容（$( ) 与反引号；单引号内不执行故跳过）。
+ * 双引号内的替换仍执行，照常提取。嵌套由 collectBashCandidates 递归处理。
+ */
+export function extractSubstitutions(text: string): string[] {
+	const found: string[] = [];
+	let quote: string | null = null;
+	let escaped = false;
+	for (let i = 0; i < text.length; i++) {
+		const ch = text[i];
+		if (escaped) {
+			escaped = false;
+			continue;
+		}
+		if (ch === "\\" && quote !== "'") {
+			escaped = true;
+			continue;
+		}
+		if (quote === "'") {
+			if (ch === "'") quote = null;
+			continue;
+		}
+		if (ch === "'" && quote === null) {
+			quote = "'";
+			continue;
+		}
+		if (ch === '"') {
+			quote = quote === '"' ? null : '"';
+			continue;
+		}
+		if (ch === "`") {
+			const end = text.indexOf("`", i + 1);
+			if (end < 0) break;
+			found.push(text.slice(i + 1, end));
+			i = end;
+			continue;
+		}
+		if (ch === "$" && text[i + 1] === "(") {
+			let depth = 1;
+			let innerQuote: string | null = null;
+			let innerEscaped = false;
+			let j = i + 2;
+			for (; j < text.length && depth > 0; j++) {
+				const c = text[j];
+				if (innerEscaped) {
+					innerEscaped = false;
+					continue;
+				}
+				if (c === "\\" && innerQuote !== "'") {
+					innerEscaped = true;
+					continue;
+				}
+				if (innerQuote) {
+					if (c === innerQuote) innerQuote = null;
+					continue;
+				}
+				if (c === "'" || c === '"') {
+					innerQuote = c;
+					continue;
+				}
+				if (c === "(") depth++;
+				if (c === ")") depth--;
+			}
+			if (depth === 0) {
+				found.push(text.slice(i + 2, j - 1));
+				i = j - 1;
+			} else {
+				break;
+			}
+		}
+	}
+	return found;
+}
+
+const WRAPPER_SHELLS = new Set(["sh", "bash", "zsh", "dash", "ash", "ksh", "fish"]);
+
+/** 去外层配对引号；有尾随内容时截取引号内部分（`'cmd' extra` → `cmd`） */
+function extractQuoted(text: string): string {
+	const q = text[0];
+	if (q !== "'" && q !== '"') return text;
+	const end = text.indexOf(q, 1);
+	return end > 0 ? text.slice(1, end) : text.slice(1);
+}
+
+/**
+ * 提取包装执行的真实命令：`sh|bash|... -c <cmd>`（含 -lc 等合并 flag）与 `eval <cmd>`。
+ * 无法提取返回 null。xargs / find -exec / python -c 等其余包装不在覆盖范围（模式方案天花板）。
+ */
+export function extractShellExecArg(segment: string): string | null {
+	const tokens = segment.trim().split(/\s+/);
+	if (tokens[0] === "eval" && tokens.length > 1) {
+		return extractQuoted(tokens.slice(1).join(" ").trim());
+	}
+	if (!WRAPPER_SHELLS.has(tokens[0] ?? "")) return null;
+	let i = 1;
+	while (i < tokens.length) {
+		const flag = tokens[i];
+		if (!flag || !/^-[a-zA-Z]+$/.test(flag)) break;
+		if (flag.includes("c")) {
+			const rest = tokens
+				.slice(i + 1)
+				.join(" ")
+				.trim();
+			return rest.length > 0 ? extractQuoted(rest) : null;
+		}
+		i++;
+	}
+	return null;
+}
+
+/**
+ * 收集 bash 求值候选：整串（兼容 "curl * | sh*" 整串模式）+ 各段 +
+ * 命令替换内容与 -c/eval 包装参数（递归，嵌套替换/包装逐层剥开）。
+ */
+function collectBashCandidates(command: string): string[] {
+	const candidates = new Set<string>();
+	const visited = new Set<string>();
+	const walk = (text: string) => {
+		if (visited.has(text)) return;
+		visited.add(text);
+		candidates.add(text);
+		for (const segment of splitShellSegments(text)) {
+			candidates.add(segment);
+			const execArg = extractShellExecArg(segment);
+			if (execArg) {
+				candidates.add(execArg);
+				walk(execArg);
+			}
+		}
+		for (const sub of extractSubstitutions(text)) {
+			candidates.add(sub);
+			walk(sub);
+		}
+	};
+	walk(command);
+	return [...candidates];
+}
+
+/**
+ * bash 命令链求值：所有候选（见 collectBashCandidates）分别求值，动作取最严
+ * （deny > ask > allow）——`cd x && ls && rm -rf y`、`echo $(rm -rf y)` 均无法绕过。
+ * segment 返回命中最终动作的候选（供弹窗标题定位危险命令；无分隔符时即整串）。
+ */
+export function evaluateBashCommand(
+	rules: PermissionRules,
+	command: string,
+	fallback: PermissionAction = "ask",
+): { action: PermissionAction; segment: string } {
+	// 从最松（allow）起步，候选结果各自已含 fallback，取最严者
+	let action: PermissionAction = "allow";
+	let segment = command;
+	for (const candidate of collectBashCandidates(command)) {
+		const a = evaluateSingle(rules, "bash", candidate, fallback);
+		if (ACTION_PRIORITY[a] > ACTION_PRIORITY[action]) {
+			action = a;
+			segment = candidate;
+		}
+	}
+	return { action, segment };
+}
+
+/**
+ * 规则求值：bash 走命令链切段（evaluateBashCommand），其余工具单段求值。
+ */
+export function evaluateRules(
+	rules: PermissionRules,
+	toolName: string,
+	matchText: string | null,
+	fallback: PermissionAction = "ask",
+): PermissionAction {
+	if (toolName === "bash" && matchText !== null) {
+		return evaluateBashCommand(rules, matchText, fallback).action;
+	}
+	return evaluateSingle(rules, toolName, matchText, fallback);
 }
 
 /** 从 tool_call 输入提取匹配文本；无法提取（自定义工具）返回 null */
@@ -121,7 +357,8 @@ export function matchTextFor(toolName: string, input: Record<string, unknown>): 
 
 /**
  * ask 弹窗的模式键（PermissionGate 的 allowAlways 按 title 记忆 = 会话白名单）。
- * bash 取前两 token（第二 token 须为子命令形态），其余工具用精确路径/工具名。
+ * bash 取前两 token（第二 token 须为子命令形态如 `git push` 或 flag 形态如 `rm -rf`），
+ * 其余工具用精确路径/工具名。flag 规整让 allowAlways 粒度是「rm -rf*」而非「rm*」。
  */
 export function suggestPattern(toolName: string, input: Record<string, unknown>): string {
 	const matchText = matchTextFor(toolName, input);
@@ -129,7 +366,7 @@ export function suggestPattern(toolName: string, input: Record<string, unknown>)
 		const tokens = matchText.trim().split(/\s+/);
 		const first = tokens[0] ?? "";
 		const second = tokens[1] ?? "";
-		if (first && /^[a-zA-Z][a-zA-Z0-9-]*$/.test(second)) {
+		if (first && /^(?:[a-zA-Z][a-zA-Z0-9-]*|-[a-zA-Z][a-zA-Z0-9-]*)$/.test(second)) {
 			return `bash: ${first} ${second}*`;
 		}
 		return `bash: ${first}*`;

--- a/packages/backend/src/pi-backend.ts
+++ b/packages/backend/src/pi-backend.ts
@@ -161,7 +161,7 @@ export class PiBackend {
 			cwd,
 			agentDir,
 			settingsManager,
-			extensionFactories: enableGate ? [makePermissionGateExtension(agentDir)] : [],
+			extensionFactories: enableGate ? [makePermissionGateExtension(agentDir, { projectRoot: cwd })] : [],
 		});
 		if (this.options.projectTrust === false) {
 			settingsManager.setProjectTrusted(true);

--- a/packages/backend/test/permission-extension.test.ts
+++ b/packages/backend/test/permission-extension.test.ts
@@ -21,8 +21,12 @@ function makeAgentDir(): string {
 }
 
 /** 挂载扩展并返回 tool_call 触发器；confirmAnswer 控制弹窗结果 */
-function makeHarness(agentDir: string, confirmAnswer: boolean | ((title: string) => boolean) = false) {
-	const extension = makePermissionGateExtension(agentDir);
+function makeHarness(
+	agentDir: string,
+	confirmAnswer: boolean | ((title: string) => boolean) = false,
+	options?: { projectRoot?: string },
+) {
+	const extension = makePermissionGateExtension(agentDir, options);
 	if (typeof extension === "function" || !("factory" in extension)) {
 		throw new Error("expected named inline extension");
 	}
@@ -62,7 +66,7 @@ describe("permission-gate 扩展", () => {
 		const { call, confirms } = makeHarness(makeAgentDir(), true);
 		await expect(call("bash", { command: "rm -rf /tmp/x" })).resolves.toBeUndefined();
 		expect(confirms).toHaveLength(1);
-		expect(confirms[0].title).toBe("bash: rm*");
+		expect(confirms[0].title).toBe("bash: rm -rf*");
 		expect(confirms[0].message).toBe("rm -rf /tmp/x");
 	});
 
@@ -71,6 +75,16 @@ describe("permission-gate 扩展", () => {
 		const result = await call("bash", { command: "sudo rm -rf /" });
 		expect(result).toMatchObject({ block: true });
 		expect((result as ToolCallEventResult).reason).toContain("denied");
+	});
+
+	it("命令链中藏高危命令同样弹窗；标题定位危险段", async () => {
+		const { call, confirms } = makeHarness(makeAgentDir(), false);
+		const result = await call("bash", { command: "cd /tmp && ls && rm -rf xxx" });
+		expect(result).toMatchObject({ block: true });
+		expect((result as ToolCallEventResult).reason).toContain("denied");
+		expect(confirms).toHaveLength(1);
+		expect(confirms[0].title).toBe("bash: rm -rf*");
+		expect(confirms[0].message).toBe("cd /tmp && ls && rm -rf xxx");
 	});
 
 	it("deny 规则直接 block，不弹窗", async () => {
@@ -92,6 +106,25 @@ describe("permission-gate 扩展", () => {
 		const { call, confirms } = makeHarness(dir, false);
 		await expect(call("bash", { command: "rm -rf /" })).resolves.toBeUndefined();
 		expect(confirms).toHaveLength(0);
+	});
+
+	it("项目边界：根外路径弹窗（含 ../../ 相对逃逸），根内与不设边界放行", async () => {
+		const dir = makeAgentDir();
+		const root = join(dir, "proj");
+		mkdirSync(root, { recursive: true });
+		const { call, confirms } = makeHarness(dir, false, { projectRoot: root });
+		// 根内绝对/相对路径直接放行
+		await expect(call("edit", { path: join(root, "a.ts") })).resolves.toBeUndefined();
+		await expect(call("read", { path: "src/b.ts" })).resolves.toBeUndefined();
+		// 根外绝对路径与 ../../ 相对逃逸都弹窗（confirmAnswer=false → block）
+		await expect(call("edit", { path: "/etc/hosts" })).resolves.toMatchObject({ block: true });
+		await expect(call("write", { path: "../../escape.ts" })).resolves.toMatchObject({ block: true });
+		expect(confirms.map((c) => c.title)).toEqual(["edit: /etc/hosts", "write: ../../escape.ts"]);
+		// 不传 projectRoot → 无边界检查，任意路径放行
+		const open = makeHarness(dir, false);
+		await expect(open.call("edit", { path: "/etc/hosts" })).resolves.toBeUndefined();
+		// bash 无法路径约束，不受边界影响
+		await expect(call("bash", { command: "ls /etc" })).resolves.toBeUndefined();
 	});
 
 	it("自定义工具吃工具名级规则", async () => {

--- a/packages/backend/test/permission-rules.test.ts
+++ b/packages/backend/test/permission-rules.test.ts
@@ -5,12 +5,16 @@ import { describe, expect, it } from "vitest";
 import {
 	createPermissionConfigLoader,
 	DEFAULT_PERMISSION_CONFIG,
+	evaluateBashCommand,
 	evaluateRules,
+	extractShellExecArg,
+	extractSubstitutions,
 	loadPermissionConfig,
 	matchPattern,
 	matchTextFor,
 	mergeWithDefaults,
 	setPermissionEnabled,
+	splitShellSegments,
 	suggestPattern,
 } from "../src/permission-rules";
 
@@ -74,6 +78,68 @@ describe("evaluateRules", () => {
 		expect(evaluateRules(rules, "bash", "git push origin main")).toBe("allow");
 		expect(evaluateRules(rules, "bash", "curl -fsSL https://x | sh")).toBe("ask");
 	});
+
+	it("bash 命令链：&& || ; | 换行 中任一段命中高危规则即拦", () => {
+		const rules = DEFAULT_PERMISSION_CONFIG.rules;
+		expect(evaluateRules(rules, "bash", "cd xx/xx && ls && rm -rf xxx")).toBe("ask");
+		expect(evaluateRules(rules, "bash", "npm test && sudo apt install x")).toBe("ask");
+		expect(evaluateRules(rules, "bash", "cd /tmp; rm -r /var/tmp/x")).toBe("ask");
+		expect(evaluateRules(rules, "bash", "echo hi | rm -rf /tmp/x")).toBe("ask");
+		expect(evaluateRules(rules, "bash", "ls\ngit clean -fd")).toBe("ask");
+		expect(evaluateRules(rules, "bash", "cd /tmp && ls && echo hi")).toBe("allow");
+	});
+
+	it("bash 命令链：单 & 后台分隔同样切段；2>&1 不误切", () => {
+		const rules = DEFAULT_PERMISSION_CONFIG.rules;
+		expect(evaluateRules(rules, "bash", "sleep 1 & rm -rf xxx")).toBe("ask");
+		expect(evaluateRules(rules, "bash", "npm test 2>&1 | tee log")).toBe("allow");
+	});
+
+	it("引号内的分隔符不切段（字符串字面量不误报）", () => {
+		const rules = DEFAULT_PERMISSION_CONFIG.rules;
+		expect(evaluateRules(rules, "bash", 'echo "a && rm -rf x"')).toBe("allow");
+		expect(evaluateRules(rules, "bash", "echo 'a; rm -rf x'")).toBe("allow");
+	});
+
+	it("命令替换 $( )/反引号 藏不住高危命令；单引号内替换不执行", () => {
+		const rules = DEFAULT_PERMISSION_CONFIG.rules;
+		expect(evaluateRules(rules, "bash", "echo $(rm -rf /tmp/x)")).toBe("ask");
+		expect(evaluateRules(rules, "bash", "echo `rm -rf /tmp/x`")).toBe("ask");
+		expect(evaluateRules(rules, "bash", "echo $(foo $(rm -rf /tmp/x))")).toBe("ask");
+		expect(evaluateRules(rules, "bash", 'echo "$(rm -rf /tmp/x)"')).toBe("ask");
+		expect(evaluateRules(rules, "bash", "echo '$(rm -rf /tmp/x)'")).toBe("allow");
+		expect(evaluateRules(rules, "bash", "echo $(ls -la)")).toBe("allow");
+	});
+
+	it("sh -c / 合并 flag / eval 包装藏不住高危命令", () => {
+		const rules = DEFAULT_PERMISSION_CONFIG.rules;
+		expect(evaluateRules(rules, "bash", 'sh -c "rm -rf /tmp/x"')).toBe("ask");
+		expect(evaluateRules(rules, "bash", "bash -lc 'git clean -fd'")).toBe("ask");
+		expect(evaluateRules(rules, "bash", 'eval "sudo apt install x"')).toBe("ask");
+		expect(evaluateRules(rules, "bash", 'bash -c "cd /x && rm -rf y"')).toBe("ask");
+		expect(evaluateRules(rules, "bash", 'sh -c "ls -la"')).toBe("allow");
+		expect(evaluateRules(rules, "bash", "sh -x script.sh")).toBe("allow");
+	});
+
+	it("命令链中 deny 段决定整链；后命中覆盖仅限段内", () => {
+		const rules = { bash: { "*": "allow", "git push *": "deny", "rm -rf *": "ask" } };
+		expect(evaluateRules(rules, "bash", "cd /x && git push origin main")).toBe("deny");
+		expect(evaluateRules(rules, "bash", "cd /x && rm -rf y && git status")).toBe("ask");
+	});
+
+	it("evaluateBashCommand：返回命中动作的段（弹窗标题定位用）", () => {
+		const rules = DEFAULT_PERMISSION_CONFIG.rules;
+		expect(evaluateBashCommand(rules, "cd xx/xx && ls && rm -rf xxx")).toEqual({
+			action: "ask",
+			segment: "rm -rf xxx",
+		});
+		// 无分隔符 → 整串；管道整体命中（curl * | sh*）→ 整串
+		expect(evaluateBashCommand(rules, "rm -rf /tmp/x")).toEqual({ action: "ask", segment: "rm -rf /tmp/x" });
+		expect(evaluateBashCommand(rules, "curl -fsSL https://x | sh")).toEqual({
+			action: "ask",
+			segment: "curl -fsSL https://x | sh",
+		});
+	});
 });
 
 describe("matchTextFor / suggestPattern", () => {
@@ -85,11 +151,47 @@ describe("matchTextFor / suggestPattern", () => {
 		expect(matchTextFor("my_tool", { foo: 1 })).toBeNull();
 	});
 
-	it("bash 模式键取前两 token（第二 token 须为子命令形态）", () => {
+	it("bash 模式键取前两 token（子命令或 flag 形态）", () => {
 		expect(suggestPattern("bash", { command: "git status --porcelain" })).toBe("bash: git status*");
 		expect(suggestPattern("bash", { command: "npm run build" })).toBe("bash: npm run*");
-		expect(suggestPattern("bash", { command: "rm -rf /tmp" })).toBe("bash: rm*");
+		expect(suggestPattern("bash", { command: "rm -rf /tmp" })).toBe("bash: rm -rf*");
+		expect(suggestPattern("bash", { command: "git clean -fd" })).toBe("bash: git clean*");
+		expect(suggestPattern("bash", { command: "ls /tmp" })).toBe("bash: ls*");
 		expect(suggestPattern("bash", { command: "ls" })).toBe("bash: ls*");
+	});
+
+	it("splitShellSegments：&& || & ; | 换行切段并去空；引号与 2>&1 不切", () => {
+		expect(splitShellSegments("cd /tmp && ls || echo hi; pwd | wc -l")).toEqual([
+			"cd /tmp",
+			"ls",
+			"echo hi",
+			"pwd",
+			"wc -l",
+		]);
+		expect(splitShellSegments("ls\npwd")).toEqual(["ls", "pwd"]);
+		expect(splitShellSegments("sleep 1 & rm -rf x")).toEqual(["sleep 1", "rm -rf x"]);
+		expect(splitShellSegments('echo "a && b"; c')).toEqual(['echo "a && b"', "c"]);
+		expect(splitShellSegments("npm test 2>&1 | tee log")).toEqual(["npm test 2>&1", "tee log"]);
+		expect(splitShellSegments("npm test")).toEqual(["npm test"]);
+		expect(splitShellSegments("   ")).toEqual([]);
+	});
+
+	it("extractSubstitutions：$( )/反引号提取，单引号内跳过", () => {
+		expect(extractSubstitutions("echo $(rm -rf x)")).toEqual(["rm -rf x"]);
+		expect(extractSubstitutions("echo `rm -rf x`")).toEqual(["rm -rf x"]);
+		expect(extractSubstitutions('echo "$(a) `b`"')).toEqual(["a", "b"]);
+		expect(extractSubstitutions("echo '$(rm -rf x)'")).toEqual([]);
+		expect(extractSubstitutions("echo $(foo $(bar))")).toEqual(["foo $(bar)"]);
+		expect(extractSubstitutions("ls -la")).toEqual([]);
+	});
+
+	it("extractShellExecArg：-c / 合并 flag / eval 提取真实命令", () => {
+		expect(extractShellExecArg('sh -c "rm -rf x"')).toBe("rm -rf x");
+		expect(extractShellExecArg("bash -lc 'ls -la'")).toBe("ls -la");
+		expect(extractShellExecArg("sh -c 'rm -rf x' extra")).toBe("rm -rf x");
+		expect(extractShellExecArg('eval "sudo x"')).toBe("sudo x");
+		expect(extractShellExecArg("sh -x script.sh")).toBeNull();
+		expect(extractShellExecArg("ls -la")).toBeNull();
 	});
 
 	it("文件工具用精确路径；自定义工具用工具名", () => {

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@pi-desktop/desktop",
-	"version": "0.1.2",
+	"version": "0.1.3",
 	"private": true,
 	"description": "Desktop GUI for the Pi coding agent",
 	"author": "Jaxton07",


### PR DESCRIPTION
## 问题

bash 权限拦截只对以高危命令开头的整串生效，链式命令可绕过：`cd xx && ls && rm -rf xxx` 不弹审批。另外文件工具访问项目外路径完全无审批。

## 修复

**bash 命令链取最严段（deny > ask > allow）**
- `splitShellSegments` 重写为引号感知扫描：`&& || & | ;` 换行在引号外才分隔；补上单 `&`（`sleep 1 & rm -rf x` 原可绕过）；`2>&1` 不误切；`echo "a && rm -rf x"` 字面量不再误报
- 新增 `extractSubstitutions`：`$( )`/反引号内容纳入求值（单引号内跳过、双引号内照提取、嵌套递归）——`echo $(rm -rf x)` 拦截
- 新增 `extractShellExecArg`：`sh -c`/`bash -lc` 合并 flag/`eval` 剥壳提取真实命令
- 整串保留为候选，`curl * | sh*` 整串模式兼容不变

**弹窗标题粒度**
- `suggestPattern` 第二 token 为 flag 形态时取两 token：`rm -rf xxx` → `bash: rm -rf*`（原 `bash: rm*`），「总是允许」不再白名单所有 rm
- 扩展内 bash 单次求值同时拿 action+segment，消除重复求值

**项目边界**
- `makePermissionGateExtension(agentDir, { projectRoot })`：read/edit/write/ls 路径 resolve 后落在会话 cwd 外（含 `../../` 相对逃逸）→ allow 提升为 ask；pi-backend 传会话 cwd。bash 无法路径约束，不覆盖

已知天花板（模式方案固有，代码注释已标明）：xargs / find -exec / python -c 包装、符号链接逃逸。

## 测试

backend 91 全过（新增 12 个用例：& 链、引号、替换、-c/eval、边界、标题粒度）；lint / typecheck 干净。