### PR TITLE
feat: splash screen with particle swarm and ripple exit (0.2.0)

### DIFF
--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@pi-desktop/desktop",
-	"version": "0.1.9",
+	"version": "0.2.0",
 	"private": true,
 	"description": "Desktop GUI for the Pi coding agent",
 	"author": "Jaxton07",

--- a/packages/desktop/src/main/dev-agent-dir.ts
+++ b/packages/desktop/src/main/dev-agent-dir.ts
@@ -1,0 +1,30 @@
+import { copyFileSync, existsSync, mkdirSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { app } from "electron";
+
+// 开发/预览态隔离 pi 用户数据：正式态与 CLI 共享 ~/.pi/agent，dev 直接跑会污染
+// 正式 sessions 与配置。SDK getAgentDir() 最优先读 PI_CODING_AGENT_DIR（每次调用
+// 实时读取、无缓存），在 main 入口最早设置即全链路生效（sessions/auth/models/
+// trust/permissions/skills 全部派生自它）。必须早于 backend 的任何路径解析
+// （index.ts 顶部 side-effect import，与 pi-package-dir 同模式）。
+// 用户显式设置了 PI_CODING_AGENT_DIR 时尊重之，不做任何处理。
+if (!app.isPackaged && !process.env.PI_CODING_AGENT_DIR) {
+	const devDir = join(homedir(), ".pi", "agent-dev");
+	const prodDir = join(homedir(), ".pi", "agent");
+	process.env.PI_CODING_AGENT_DIR = devDir;
+	mkdirSync(devDir, { recursive: true });
+	// 一次性种子拷贝（只读正式、只写 dev，目标已存在跳过，之后两边互不影响）：
+	// 无凭证/模型 dev 起不来；settings/permissions/trust 拷过去免去重复配置。
+	// 目录类资源（skills/extensions/themes/prompts）不拷，dev 独立发展。
+	for (const name of ["auth.json", "models.json", "settings.json", "permissions.json", "trust.json"]) {
+		const src = join(prodDir, name);
+		const dest = join(devDir, name);
+		try {
+			if (existsSync(src) && !existsSync(dest)) copyFileSync(src, dest);
+		} catch {
+			// 种子拷贝失败不阻断启动
+		}
+	}
+	console.log(`[dev-agent-dir] PI_CODING_AGENT_DIR=${devDir}（与正式 ~/.pi/agent 隔离）`);
+}

--- a/packages/desktop/src/main/index.ts
+++ b/packages/desktop/src/main/index.ts
@@ -1,4 +1,5 @@
 import "./pi-package-dir";
+import "./dev-agent-dir";
 import { writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { pathToFileURL } from "node:url";
@@ -42,10 +43,10 @@ protocol.registerSchemesAsPrivileged([
 	{ scheme: BG_PROTOCOL, privileges: { standard: true, secure: true, supportFetchAPI: true } },
 ]);
 
-/** 窗口启动底色跟随主题，避免深色模式下启动白闪 */
-function resolveWindowBackground(theme: ThemeMode | undefined): string {
+/** 解析保存的主题为明确的深浅色（system 时跟随系统），窗口底色与 ?theme= 传参同源 */
+function resolveTheme(theme: ThemeMode | undefined): "dark" | "light" {
 	const dark = theme === "dark" || (theme !== "light" && nativeTheme.shouldUseDarkColors);
-	return dark ? "#17171a" : "#fafafa";
+	return dark ? "dark" : "light";
 }
 
 function sendToRenderer(channel: string, payload: unknown): void {
@@ -246,10 +247,10 @@ app.whenReady().then(async () => {
 	initUpdater();
 	scheduleAutoUpdateCheck();
 	const uiState = await loadUiState();
-	createWindow(resolveWindowBackground(uiState?.theme));
+	createWindow(resolveTheme(uiState?.theme));
 
 	app.on("activate", () => {
-		if (BrowserWindow.getAllWindows().length === 0) createWindow(resolveWindowBackground(uiState?.theme));
+		if (BrowserWindow.getAllWindows().length === 0) createWindow(resolveTheme(uiState?.theme));
 	});
 });
 

--- a/packages/desktop/src/main/window.ts
+++ b/packages/desktop/src/main/window.ts
@@ -3,7 +3,12 @@ import { BrowserWindow, shell } from "electron";
 
 const __dirname = import.meta.dirname;
 
-export function createWindow(backgroundColor = "#fafafa"): BrowserWindow {
+/** 窗口启动底色跟随主题，避免深色模式下启动白闪（也是开屏动画的底色） */
+function windowBackground(theme: "dark" | "light"): string {
+	return theme === "dark" ? "#17171a" : "#fafafa";
+}
+
+export function createWindow(theme: "dark" | "light" = "light"): BrowserWindow {
 	const window = new BrowserWindow({
 		width: 1100,
 		height: 750,
@@ -12,7 +17,7 @@ export function createWindow(backgroundColor = "#fafafa"): BrowserWindow {
 		show: false,
 		titleBarStyle: "hiddenInset",
 		trafficLightPosition: { x: 16, y: 16 },
-		backgroundColor,
+		backgroundColor: windowBackground(theme),
 		webPreferences: {
 			preload: join(__dirname, "../preload/index.cjs"),
 			contextIsolation: true,
@@ -28,10 +33,13 @@ export function createWindow(backgroundColor = "#fafafa"): BrowserWindow {
 		return { action: "deny" };
 	});
 
+	// 已解析主题经 query 传给 renderer（bootstrap-theme.ts 首帧前写入 data-theme）
 	if (process.env.ELECTRON_RENDERER_URL) {
-		void window.loadURL(process.env.ELECTRON_RENDERER_URL);
+		const url = new URL(process.env.ELECTRON_RENDERER_URL);
+		url.searchParams.set("theme", theme);
+		void window.loadURL(url.toString());
 	} else {
-		void window.loadFile(join(__dirname, "../renderer/index.html"));
+		void window.loadFile(join(__dirname, "../renderer/index.html"), { search: `theme=${theme}` });
 	}
 
 	return window;

--- a/packages/desktop/src/renderer/index.html
+++ b/packages/desktop/src/renderer/index.html
@@ -8,9 +8,14 @@
       content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: pi-bg:; font-src 'self' data:"
     />
     <title>Pi Desktop</title>
+    <!-- 开屏动画（黑白哑光粒子光团 → 散场）：样式 splash.css（渲染阻塞，首帧前就绪）；
+         DOM 由 splash-dom.ts 在首帧前同步生成（粒子参数程序化生成）；收場控制见 splash.ts。 -->
+    <link rel="stylesheet" href="/src/styles/splash.css" />
   </head>
   <body>
     <div id="root"></div>
+    <script type="module" src="/src/bootstrap-theme.ts"></script>
+    <script type="module" src="/src/splash-dom.ts"></script>
     <script type="module" src="/src/main.tsx"></script>
   </body>
 </html>

--- a/packages/desktop/src/renderer/src/App.tsx
+++ b/packages/desktop/src/renderer/src/App.tsx
@@ -9,6 +9,7 @@ import { ApprovalDock } from "./components/session/ApprovalDock";
 import { SessionTabBar } from "./components/session/SessionTabBar";
 import { TrustDialog } from "./components/session/TrustDialog";
 import { SettingsDialog } from "./components/settings/SettingsDialog";
+import { finishSplash } from "./splash";
 import { useSessionsStore } from "./stores/sessions";
 import { backgroundImageUrl, useThemeStore } from "./stores/theme";
 import { useTranscriptStore } from "./stores/transcript";
@@ -52,8 +53,11 @@ export default function App() {
 		const offTrust = pi.onTrustRequest((req) => {
 			setTrustRequests((prev) => [...prev, req]);
 		});
-		void useSessionsStore.getState().loadModels();
-		void useSessionsStore.getState().restoreTabs();
+		// 开屏就绪信号：首批数据（模型列表 + 恢复标签页）settle 后绽放收場（finishSplash 幂等）
+		void Promise.allSettled([
+			useSessionsStore.getState().loadModels(),
+			useSessionsStore.getState().restoreTabs(),
+		]).then(() => finishSplash());
 		initUpdateStore();
 		return () => {
 			offEvent();

--- a/packages/desktop/src/renderer/src/bootstrap-theme.ts
+++ b/packages/desktop/src/renderer/src/bootstrap-theme.ts
@@ -1,0 +1,8 @@
+/**
+ * 首帧前写入 data-theme：主题由主进程经 ?theme= 传入（与窗口 backgroundColor 同源，
+ * 见 main/window.ts），splash 配色与 body 底色因此零等待即正确。
+ * 缺参（如浏览器直开）回退系统偏好；theme store init 之后以同值覆盖，幂等。
+ */
+const param = new URLSearchParams(location.search).get("theme");
+const system = window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light";
+document.documentElement.dataset.theme = param === "dark" || param === "light" ? param : system;

--- a/packages/desktop/src/renderer/src/main.tsx
+++ b/packages/desktop/src/renderer/src/main.tsx
@@ -1,11 +1,15 @@
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 import App from "./App";
+import { initSplash } from "./splash";
 import { useThemeStore } from "./stores/theme";
 import "./styles/globals.css";
 
 const root = document.getElementById("root");
 if (!root) throw new Error("root element not found");
+
+// 开屏：同次运行已播过则立即移除，否则挂最长兜底（收場时机见 App.tsx 的 finishSplash）
+initSplash();
 
 // render 前先恢复主题/背景（一次 IPC），避免深色模式启动闪白
 void useThemeStore

--- a/packages/desktop/src/renderer/src/splash-dom.ts
+++ b/packages/desktop/src/renderer/src/splash-dom.ts
@@ -1,0 +1,44 @@
+/**
+ * 开屏 DOM 生成：index.html 中排在主 bundle 前的独立 module，首帧前同步建 DOM
+ * （样式 splash.css 渲染阻塞先行就绪，动画是纯 CSS keyframes，本文件只一次性建 DOM）。
+ * 粒子参数由黄金角螺旋程序化生成 —— 调整数量只需改 DOT_COUNT。
+ */
+
+const DOT_COUNT = 64;
+const GOLDEN_ANGLE_RAD = 137.508 * (Math.PI / 180);
+const SPREAD = 13.2; // 半径 = SPREAD * sqrt(i)，最外圈约 105px
+
+function buildDots(): string {
+	let html = "";
+	for (let i = 1; i <= DOT_COUNT; i++) {
+		const r = SPREAD * Math.sqrt(i);
+		const theta = i * GOLDEN_ANGLE_RAD;
+		const x = Math.round(r * Math.cos(theta));
+		const y = Math.round(r * Math.sin(theta));
+		// 中心大且亮、边缘小且淡；尺寸加少量档位抖动避免机械感
+		const size = Math.max(3, 13.5 - r * 0.1 + ((i * 7) % 3) - 1);
+		const opacity = Math.min(1, Math.max(0.35, 1.02 - r * 0.0065));
+		const duration = 3.1 + ((i * 13) % 37) / 10; // 3.1s – 6.7s
+		const delay = -((i * 29) % 67) / 10; // 负延迟 = 立即处于各自相位，不同步起跑
+		// 收場飞出屏外的目标点：沿各自径向向外 1100px（任何窗口都出屏）
+		const ex = Math.round(x * 3 + Math.cos(theta) * 1100);
+		const ey = Math.round(y * 3 + Math.sin(theta) * 1100);
+		html += `<i class="sp-dot" style="--x:${x}px;--y:${y}px;--ex:${ex}px;--ey:${ey}px;--s:${size.toFixed(1)}px;--o:${opacity.toFixed(2)};--t:${duration.toFixed(1)}s;--dl:${delay.toFixed(1)}s"></i>`;
+	}
+	return html;
+}
+
+const splash = document.createElement("div");
+splash.id = "splash";
+splash.setAttribute("aria-hidden", "true");
+splash.innerHTML = `
+	<div class="sp-swarm">
+		<div class="sp-swarm-in">
+			<div class="sp-swarm-breathe">${buildDots()}</div>
+		</div>
+	</div>
+	<div class="sp-rings"></div>
+	<div class="sp-wave"></div>
+	<div class="sp-word">pi</div>
+	<div class="sp-line"></div>`;
+document.body.append(splash);

--- a/packages/desktop/src/renderer/src/splash.ts
+++ b/packages/desktop/src/renderer/src/splash.ts
@@ -1,0 +1,62 @@
+/**
+ * 开屏动画（黑白哑光粒子光团 → 散场）控制。
+ * 样式 = styles/splash.css（link 渲染阻塞，首帧前就绪）；DOM = splash-dom.ts 首帧前生成；
+ * 这里只负责三件事：最短/最长展示时长、就绪后打 data-app-ready 触发收場、收場后移除 DOM。
+ */
+
+/** 最短展示时长：能看到粒子团聚拢 + 一次呼吸 + 一道声纳波纹 */
+const MIN_DISPLAY_MS = 2500;
+/** 最长兜底：backend 异常慢时也保证收場（超 2.4s 会露出慢加载细线） */
+const MAX_DISPLAY_MS = 4500;
+/** 收場时长（与 splash.css 收場编排同步：主界面 1.35s 延迟 + 淡入 1s = 2.35s 后一切落定） */
+const EXIT_MS = 2400;
+const EXIT_MS_REDUCED = 300;
+/** 同次运行只播一次（macOS activate 重建窗口不重播；调试重播 = devtools 清此键） */
+const PLAYED_KEY = "pi-splash-played";
+
+let finished = false;
+
+function markPlayed(): void {
+	try {
+		sessionStorage.setItem(PLAYED_KEY, "1");
+	} catch {
+		// sessionStorage 不可用时静默失败（下次重建窗口会重播，可接受）
+	}
+}
+
+function alreadyPlayed(): boolean {
+	try {
+		return sessionStorage.getItem(PLAYED_KEY) === "1";
+	} catch {
+		return false;
+	}
+}
+
+function removeSplash(): void {
+	document.getElementById("splash")?.remove();
+}
+
+/** 模块加载即调用：同次运行已播过则直接跳过；否则挂最长兜底定时器 */
+export function initSplash(): void {
+	if (alreadyPlayed()) {
+		finished = true;
+		// splash.css 常驻，#root 初始 visibility:hidden —— 跳过时也要放出主界面
+		document.documentElement.dataset.appReady = "true";
+		removeSplash();
+		return;
+	}
+	window.setTimeout(finishSplash, MAX_DISPLAY_MS);
+}
+
+/** 应用就绪后调用（幂等）：满最短展示时长后触发收場 */
+export function finishSplash(): void {
+	if (finished) return;
+	finished = true;
+	markPlayed();
+	const wait = Math.max(0, MIN_DISPLAY_MS - performance.now());
+	window.setTimeout(() => {
+		document.documentElement.dataset.appReady = "true";
+		const reduced = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+		window.setTimeout(removeSplash, reduced ? EXIT_MS_REDUCED : EXIT_MS);
+	}, wait);
+}

--- a/packages/desktop/src/renderer/src/styles/globals.css
+++ b/packages/desktop/src/renderer/src/styles/globals.css
@@ -243,6 +243,12 @@ body {
 	transition: background-color 0.15s ease;
 }
 
+/* 主题就绪（data-theme 写入）前 body 透明：透出窗口 backgroundColor（main 已按主题设置），
+   防深色启动时开屏动画底下闪白 */
+:root:not([data-theme]) body {
+	background: transparent;
+}
+
 /* 设置了自定义背景图时 body 透明，让 #root 内的背景层透出 */
 [data-has-bg="true"] body {
 	background: transparent;

--- a/packages/desktop/src/renderer/src/styles/splash.css
+++ b/packages/desktop/src/renderer/src/styles/splash.css
@@ -1,0 +1,340 @@
+/*
+ * 开屏动画（黑白哑光粒子光团 → 散场）样式。
+ * 经 index.html <link> 引入（渲染阻塞，首帧前就绪），不依赖任何 JS bundle；
+ * DOM 由 splash-dom.ts 在首帧前同步生成，收場时机见 splash.ts（data-app-ready 触发）。
+ * 配色挂 data-theme（bootstrap-theme.ts 首帧前写入）：深色 = 白色微光粒子，浅色 = 墨色粒子；
+ * 波浪（涟漪/冲击波）与粒子反色、随主题挂钩：浅色主题纯白 / 深色主题墨色（用户定案 2026-08）。
+ */
+
+#splash {
+	position: fixed;
+	inset: 0;
+	z-index: 9999;
+	display: grid;
+	place-items: center;
+	overflow: hidden;
+	pointer-events: none;
+}
+#splash > * {
+	grid-area: 1 / 1;
+}
+#root {
+	visibility: hidden;
+}
+html[data-app-ready] #root {
+	visibility: visible;
+	animation: sp-root-in 1s cubic-bezier(0.25, 0.46, 0.45, 0.94) 1.35s both;
+}
+
+/* 粒子团：三层嵌套分离 transform（慢转 / 入场 / 呼吸互不覆盖），粒子各自漂移明灭 */
+.sp-swarm {
+	position: relative;
+	width: 220px;
+	height: 220px;
+	color: #18181b;
+	animation: sp-spin 60s linear infinite;
+}
+html[data-theme="dark"] .sp-swarm {
+	color: #f4f4f5;
+}
+.sp-swarm-in {
+	width: 100%;
+	height: 100%;
+	opacity: 0;
+	transform: scale(0.72);
+	animation: sp-swarm-in 1.1s cubic-bezier(0.16, 1, 0.3, 1) 0.15s forwards;
+}
+.sp-swarm-breathe {
+	width: 100%;
+	height: 100%;
+	animation: sp-swarm-breathe 4.2s ease-in-out 1.3s infinite;
+}
+.sp-dot {
+	position: absolute;
+	left: 50%;
+	top: 50%;
+	width: var(--s);
+	height: var(--s);
+	margin: calc(var(--s) / -2);
+	border-radius: 50%;
+	background: radial-gradient(circle, currentColor 28%, transparent 72%);
+	opacity: var(--o);
+	transform: translate(var(--x), var(--y));
+	animation: sp-dot-drift var(--t) ease-in-out var(--dl) infinite;
+}
+
+/* 声纳涟漪：细环 + 模糊柔边（水波而非画线），透明度克制。
+   颜色与主题挂钩（与粒子反色，穿过粒子团时才有水波感）：浅色主题 = 纯白（墨色粒子上可见），深色主题 = 墨色（白色粒子上可见） */
+.sp-rings {
+	position: relative;
+	width: 220px;
+	height: 220px;
+}
+.sp-rings::before,
+.sp-rings::after {
+	content: "";
+	position: absolute;
+	inset: 0;
+	border: 1px solid rgba(255, 255, 255, 0.6);
+	border-radius: 50%;
+	filter: blur(1px);
+	opacity: 0;
+	animation: sp-sonar 3.2s cubic-bezier(0.16, 1, 0.3, 1) 1.4s infinite;
+}
+.sp-rings::after {
+	animation-delay: 3s;
+}
+html[data-theme="dark"] .sp-rings::before,
+html[data-theme="dark"] .sp-rings::after {
+	border-color: rgba(24, 24, 27, 0.6);
+}
+
+/* 收場涟漪：细环 + 模糊柔边的双环（主环 + 淡回波），从中心扩散出屏。
+   与待机声纳相反：收場时粒子已飞散，环要对**背景**可见——浅色主题 = 淡墨、深色主题 = 柔白 */
+.sp-wave {
+	position: relative;
+	width: 220px;
+	height: 220px;
+	--sp-wave-c: rgba(24, 24, 27, 0.4);
+	--po: 0.7;
+}
+html[data-theme="dark"] .sp-wave {
+	--sp-wave-c: rgba(244, 244, 245, 0.55);
+}
+.sp-wave,
+.sp-wave::after {
+	border: 1.5px solid var(--sp-wave-c);
+	border-radius: 50%;
+	filter: blur(1.5px);
+	opacity: 0;
+}
+.sp-wave::after {
+	content: "";
+	position: absolute;
+	inset: 0;
+	--po: 0.45;
+}
+
+/* 品牌字：粒子团浮现后淡入；底色同色光晕把字从粒子里托出来 */
+.sp-word {
+	font:
+		600 44px / 1 -apple-system,
+		BlinkMacSystemFont,
+		"SF Pro Text",
+		"Helvetica Neue",
+		"PingFang SC",
+		sans-serif;
+	color: #18181b;
+	letter-spacing: 0.02em;
+	text-shadow: 0 0 18px rgba(250, 250, 250, 0.9);
+	user-select: none;
+	opacity: 0;
+	transform: translateY(6px);
+	animation: sp-word-in 0.9s cubic-bezier(0.16, 1, 0.3, 1) 0.55s forwards;
+}
+html[data-theme="dark"] .sp-word {
+	color: #e6e6ea;
+	text-shadow: 0 0 18px rgba(23, 23, 26, 0.85);
+}
+
+/* 慢加载细线：2.4s 后才淡入（正常启动永远看不到） */
+.sp-line {
+	width: 140px;
+	height: 2px;
+	border-radius: 2px;
+	overflow: hidden;
+	background: rgba(24, 24, 27, 0.12);
+	opacity: 0;
+	transform: translateY(160px);
+	animation: sp-fade-in 0.6s ease-out 2.4s forwards;
+}
+.sp-line::after {
+	content: "";
+	display: block;
+	width: 100%;
+	height: 100%;
+	background: linear-gradient(90deg, transparent, rgba(24, 24, 27, 0.55), transparent);
+	transform: translateX(-100%);
+	animation: sp-sweep 1.4s ease-in-out 2.4s infinite;
+}
+html[data-theme="dark"] .sp-line {
+	background: rgba(255, 255, 255, 0.14);
+}
+html[data-theme="dark"] .sp-line::after {
+	background: linear-gradient(90deg, transparent, rgba(255, 255, 255, 0.7), transparent);
+}
+
+/* ---- 收場（data-app-ready 触发）：粒子向外爆裂飞出屏外 + 涟漪双环扩散出屏 → 屏幕归于主题纯色 → 主界面再淡入（先后不交叠） ----
+   注意：base opacity:0 的元素（ swarm-in / word / rings / line ）可见态全靠入场动画 forwards 填充，
+   收場替换动画会瞬间塌回 0 —— 必须先把 base 值显式设为当前可见值，再挂收場动画 */
+html[data-app-ready] .sp-word {
+	opacity: 1;
+	transform: translateY(0);
+	animation: sp-word-out 0.45s ease-in forwards;
+}
+html[data-app-ready] .sp-rings::before,
+html[data-app-ready] .sp-rings::after {
+	opacity: 0.35;
+	animation: sp-quick-out 0.25s ease-in forwards;
+}
+html[data-app-ready] .sp-line {
+	opacity: 1;
+	animation: sp-quick-out 0.2s ease-in forwards;
+}
+html[data-app-ready] .sp-line::after {
+	animation: none;
+}
+html[data-app-ready] .sp-dot {
+	animation: sp-dot-out 1.2s cubic-bezier(0.55, 0.06, 0.68, 0.19) 0.05s forwards;
+}
+html[data-app-ready] .sp-swarm-in {
+	opacity: 1;
+	transform: scale(1);
+	animation: sp-quick-out 0.3s ease-in 1.3s forwards;
+}
+html[data-app-ready] .sp-wave {
+	animation: sp-wave-out 1.8s cubic-bezier(0.25, 0.46, 0.45, 0.94) 0.15s forwards;
+}
+html[data-app-ready] .sp-wave::after {
+	animation: sp-wave-out 1.8s cubic-bezier(0.25, 0.46, 0.45, 0.94) 0.38s forwards;
+}
+
+@keyframes sp-fade-in {
+	to {
+		opacity: 1;
+	}
+}
+@keyframes sp-spin {
+	to {
+		transform: rotate(1turn);
+	}
+}
+@keyframes sp-swarm-in {
+	to {
+		opacity: 1;
+		transform: scale(1);
+	}
+}
+@keyframes sp-swarm-breathe {
+	0%,
+	100% {
+		transform: scale(1);
+	}
+	50% {
+		transform: scale(1.05);
+	}
+}
+@keyframes sp-dot-drift {
+	0%,
+	100% {
+		opacity: var(--o);
+		transform: translate(var(--x), var(--y)) scale(1);
+	}
+	50% {
+		opacity: calc(var(--o) * 0.45);
+		transform: translate(calc(var(--x) * 1.14), calc(var(--y) * 1.14)) scale(1.3);
+	}
+}
+@keyframes sp-sonar {
+	0% {
+		transform: scale(0.72);
+		opacity: 0;
+	}
+	15% {
+		opacity: 0.65;
+	}
+	60% {
+		opacity: 0.25;
+	}
+	100% {
+		transform: scale(2.3);
+		opacity: 0;
+	}
+}
+@keyframes sp-wave-out {
+	0% {
+		transform: scale(0.5);
+		opacity: 0;
+	}
+	8% {
+		opacity: var(--po);
+	}
+	55% {
+		opacity: calc(var(--po) * 0.7);
+	}
+	100% {
+		transform: scale(12);
+		opacity: 0;
+	}
+}
+@keyframes sp-word-in {
+	to {
+		opacity: 1;
+		transform: translateY(0);
+	}
+}
+@keyframes sp-sweep {
+	to {
+		transform: translateX(100%);
+	}
+}
+@keyframes sp-root-in {
+	from {
+		opacity: 0;
+	}
+	to {
+		opacity: 1;
+	}
+}
+@keyframes sp-quick-out {
+	to {
+		opacity: 0;
+	}
+}
+@keyframes sp-word-out {
+	to {
+		opacity: 0;
+		transform: translateY(-8px) scale(1.12);
+	}
+}
+@keyframes sp-dot-out {
+	0% {
+		opacity: var(--o);
+		transform: translate(var(--x), var(--y)) scale(1);
+	}
+	55% {
+		opacity: calc(var(--o) * 0.85);
+	}
+	100% {
+		opacity: 0;
+		transform: translate(var(--ex), var(--ey)) scale(0.6);
+	}
+}
+
+/* 减弱动态：静态粒子团 + 纯淡入淡出 */
+@media (prefers-reduced-motion: reduce) {
+	.sp-swarm,
+	.sp-dot {
+		animation: none;
+	}
+	.sp-rings,
+	.sp-wave,
+	.sp-line {
+		display: none;
+	}
+	.sp-swarm-in {
+		animation: sp-fade-in 0.2s ease-out forwards;
+	}
+	.sp-word {
+		animation: sp-word-in 0.2s ease-out 0.1s forwards;
+	}
+	html[data-app-ready] .sp-swarm-in,
+	html[data-app-ready] .sp-word {
+		opacity: 1;
+		transform: none;
+		animation: sp-quick-out 0.2s ease-in forwards;
+	}
+	html[data-app-ready] #root {
+		animation: none;
+	}
+}


### PR DESCRIPTION
## 开屏动画（黑白哑光粒子光团 → 散场）

- 首帧前渲染阻塞链路：`splash.css`（link 渲染阻塞）+ `splash-dom.ts`（同步建 DOM，粒子黄金角螺旋公式化生成，`DOT_COUNT` 64）+ `splash.ts`（最短 2.5s / 兜底 4.5s / 收場后清理）+ `bootstrap-theme.ts`（首帧 `data-theme`，主题来自 main `?theme=` query）
- 待机态：粒子团慢转/呼吸/漂移 + 双道声纳涟漪（浅底白环/深底墨环，取粒子反色）+ pi 品牌字 + 慢加载细线
- 收場（先后不交叠）：字退 → 粒子沿各自径向飞出屏外 1.2s + 涟漪双环扫屏 1.8s（对背景可见：浅底淡墨/深底柔白）→ 主题纯色 → 工作界面 1.35s 延迟淡入 1s
- 同次运行只播一次（sessionStorage），macOS activate 重建窗口不重播；`prefers-reduced-motion` 退化纯淡入淡出
- 修 `body` 启动闪白：主题就绪前 body 透明透出窗口 backgroundColor
- dev/预览态自动隔离 `PI_CODING_AGENT_DIR` 到 `~/.pi/agent-dev/`（`main/dev-agent-dir.ts`，种子拷贝 5 个小配置，正式目录零写入）
- 版本号 0.1.9 → 0.2.0，merge 后打 tag v0.2.0 发版