### PR TITLE
feat: homebrew tap + manual-install fallback for unsigned mac builds (0.2.1)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,5 +56,35 @@ jobs:
           | macOS (Intel) | `pi-desktop-mac-x64.dmg` |
           | Windows | `pi-desktop-windows-x64.exe` (installer) or `pi-desktop-windows-x64.zip` |
 
-          > Ad-hoc signed (no Developer ID). On macOS, if Gatekeeper blocks the app, right-click it and choose **Open** (or run `xattr -cr "/Applications/Pi Desktop.app"`). Installed apps update automatically via **Check for updates** in Settings → About.
+          > Ad-hoc signed (no Developer ID). On macOS, if Gatekeeper blocks the app, right-click it and choose **Open** (or run `xattr -cr "/Applications/Pi Desktop.app"`). macOS users can also install/update via Homebrew: `brew install --cask jaxton07/tap/pi-desktop` (installed via brew has no Gatekeeper prompt). Windows builds update automatically in-app.
           EOF
+  # 同步 homebrew tap（Jaxton07/homebrew-tap）：渲染 cask 模板并推送。
+  # 需要 repo secret TAP_GITHUB_TOKEN（能推 homebrew-tap 的 PAT）；未配置时此 job 失败不影响已发布的 Release
+  tap:
+    needs: publish
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+          merge-multiple: true
+      - name: Render & push cask
+        env:
+          GH_TOKEN: ${{ secrets.TAP_GITHUB_TOKEN }}
+        run: |
+          VERSION="${GITHUB_REF_NAME#v}"
+          ARM_SHA=$(sha256sum "artifacts/pi-desktop-mac-arm64.zip" | cut -d" " -f1)
+          X64_SHA=$(sha256sum "artifacts/pi-desktop-mac-x64.zip" | cut -d" " -f1)
+          git clone --depth 1 "https://x-access-token:${GH_TOKEN}@github.com/Jaxton07/homebrew-tap.git" tap
+          mkdir -p tap/Casks
+          sed -e "s/{{VERSION}}/$VERSION/g" \
+              -e "s/{{SHA256_ARM}}/$ARM_SHA/g" \
+              -e "s/{{SHA256_X64}}/$X64_SHA/g" \
+              packages/desktop/homebrew/pi-desktop.rb.template > tap/Casks/pi-desktop.rb
+          cd tap
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add Casks/pi-desktop.rb
+          git diff --cached --quiet || git commit -m "pi-desktop $VERSION"
+          git push

--- a/packages/desktop/homebrew/pi-desktop.rb.template
+++ b/packages/desktop/homebrew/pi-desktop.rb.template
@@ -1,0 +1,24 @@
+cask "pi-desktop" do
+  version "{{VERSION}}"
+
+  on_arm do
+    sha256 "{{SHA256_ARM}}"
+    url "https://github.com/Jaxton07/pi-desktop/releases/download/v#{version}/pi-desktop-mac-arm64.zip"
+  end
+  on_intel do
+    sha256 "{{SHA256_X64}}"
+    url "https://github.com/Jaxton07/pi-desktop/releases/download/v#{version}/pi-desktop-mac-x64.zip"
+  end
+
+  name "Pi Desktop"
+  desc "Desktop GUI for the Pi coding agent"
+  homepage "https://github.com/Jaxton07/pi-desktop"
+
+  app "Pi Desktop.app"
+
+  zap trash: [
+    "~/Library/Application Support/@pi-desktop",
+    "~/Library/Caches/io.github.jaxton07.pi-desktop",
+    "~/Library/Caches/@pi-desktopdesktop-updater",
+  ]
+end

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@pi-desktop/desktop",
-	"version": "0.2.0",
+	"version": "0.2.1",
 	"private": true,
 	"description": "Desktop GUI for the Pi coding agent",
 	"author": "Jaxton07",

--- a/packages/desktop/src/main/index.ts
+++ b/packages/desktop/src/main/index.ts
@@ -244,7 +244,7 @@ app.whenReady().then(async () => {
 	backend = new PiBackend();
 	await backend.init();
 	registerIpc();
-	initUpdater();
+	await initUpdater();
 	scheduleAutoUpdateCheck();
 	const uiState = await loadUiState();
 	createWindow(resolveTheme(uiState?.theme));

--- a/packages/desktop/src/main/updater.ts
+++ b/packages/desktop/src/main/updater.ts
@@ -1,3 +1,4 @@
+import { execFile } from "node:child_process";
 import { createRequire } from "node:module";
 import { createLogger } from "@pi-desktop/backend";
 import type { UpdateState } from "@pi-desktop/shared";
@@ -19,6 +20,31 @@ let latestVersion: string | null = null;
 let downloaded = false;
 /** 已上报的 phase：下载中/已下载时屏蔽 checking/not-available，防按钮闪烁/消失 */
 let currentPhase: UpdateState["phase"] | null = null;
+/** 当前构建无法自动安装（mac adhoc/未签名）→ 更新只提示，点击跳 release 页手动下载 */
+let manualInstall = false;
+
+/**
+ * mac 上 Squirrel 安装前强制校验代码签名（旧 app 的 designated requirement），
+ * adhoc/未签名构建必失败且静默无反应 → 检测出来走手动下载流程；正式签名后自动恢复正常路径
+ */
+function detectManualInstall(): Promise<boolean> {
+	if (process.platform !== "darwin") return Promise.resolve(false);
+	const exe = app.getPath("exe");
+	const appIndex = exe.indexOf(".app/");
+	if (appIndex === -1) return Promise.resolve(true);
+	const bundlePath = exe.slice(0, appIndex + ".app".length);
+	return new Promise((resolve) => {
+		// codesign -dv 的信息输出在 stderr；命令失败（含完全未签名）也按手动安装处理
+		execFile("codesign", ["-dv", bundlePath], (error, _stdout, stderr) => {
+			if (error) {
+				log.warn("codesign check failed, fallback to manual install", error.message);
+				resolve(true);
+				return;
+			}
+			resolve(stderr.includes("Signature=adhoc"));
+		});
+	});
+}
 
 export function onUpdateState(cb: Listener): void {
 	listeners.add(cb);
@@ -34,8 +60,12 @@ function emit(state: UpdateState): void {
 }
 
 /** 初始化 autoUpdater 事件转发；dev 模式（未打包）无 app-update.yml，直接跳过 */
-export function initUpdater(): void {
+export async function initUpdater(): Promise<void> {
 	if (!app.isPackaged) return;
+	manualInstall = await detectManualInstall();
+	if (manualInstall) {
+		log.info("unsigned/adhoc build: auto-install disabled, update clicks open the release page");
+	}
 	// 不做后台自动下载：发现新版只发 available 提示，用户点击后才下载
 	autoUpdater.autoDownload = false;
 	// 兜底：若下载完成后安装流程未执行，用户完全退出 app 时自动安装
@@ -46,7 +76,7 @@ export function initUpdater(): void {
 	autoUpdater.on("checking-for-update", () => emit({ phase: "checking" }));
 	autoUpdater.on("update-available", (info) => {
 		latestVersion = info.version;
-		emit({ phase: "available", version: info.version });
+		emit({ phase: "available", version: info.version, manual: manualInstall });
 	});
 	autoUpdater.on("update-not-available", () => emit({ phase: "not-available" }));
 	autoUpdater.on("download-progress", (progress) => {
@@ -65,7 +95,7 @@ export function initUpdater(): void {
 		if (downloaded) return;
 		if (latestVersion) {
 			// 下载失败 → 回退到「发现新版本」保留下载入口，用户可重试
-			emit({ phase: "available", version: latestVersion });
+			emit({ phase: "available", version: latestVersion, manual: manualInstall });
 		} else {
 			emit({ phase: "error", message: error instanceof Error ? error.message : String(error) });
 		}
@@ -75,11 +105,12 @@ export function initUpdater(): void {
 /**
  * 检查更新 / 下载更新（renderer 两个入口同走这里）：
  * 已发现新版且未下载 → 直接下载；否则先检查（autoDownload=false 时发现新版不会自动下载）。
+ * manual 构建不下载（装了也过不了签名校验），重复调用只重查。
  */
 export async function checkForUpdates(): Promise<void> {
 	if (!app.isPackaged) return;
 	try {
-		if (latestVersion && !downloaded) {
+		if (latestVersion && !downloaded && !manualInstall) {
 			// 立即上报 downloading（download-progress 首个事件可能滞后），按钮马上变进度环
 			emit({ phase: "downloading", version: latestVersion, percent: 0 });
 			await autoUpdater.downloadUpdate();

--- a/packages/desktop/src/renderer/src/components/session/UpdateButton.tsx
+++ b/packages/desktop/src/renderer/src/components/session/UpdateButton.tsx
@@ -7,7 +7,7 @@ import { Tooltip } from "../ui/Tooltip";
 const RING_RADIUS = 8.5;
 const CIRCUMFERENCE = 2 * Math.PI * RING_RADIUS;
 
-/** 顶栏更新按钮：无更新不渲染；发现新版=下载图标+角标（点击开始下载），下载中=淡蓝进度环，下载完=「重启」胶囊（点击安装重启） */
+/** 顶栏更新按钮：无更新不渲染；发现新版=下载图标+角标（点击开始下载；manual 构建改跳 release 页），下载中=进度环，下载完=「重启」胶囊（点击安装重启） */
 export function UpdateButton() {
 	const t = useT();
 	const state = useUpdateStore((s) => s.state);
@@ -16,12 +16,19 @@ export function UpdateButton() {
 		return null;
 	}
 
+	const openReleasePage = async (version: string) => {
+		const info = await getPi().getAppInfo();
+		void getPi().openExternal(`${info.repoUrl}/releases/tag/v${version}`);
+	};
+
 	const label =
 		state.phase === "downloading"
 			? t("update.downloading", { percent: state.percent })
 			: state.phase === "downloaded"
 				? t("update.installNow")
-				: t("update.available", { version: state.version });
+				: state.phase === "available" && state.manual
+					? t("update.availableManual", { version: state.version })
+					: t("update.available", { version: state.version });
 
 	if (state.phase === "downloaded") {
 		return (
@@ -43,9 +50,11 @@ export function UpdateButton() {
 			<button
 				type="button"
 				aria-label={label}
-				className="no-drag relative flex h-6 w-6 shrink-0 items-center justify-center rounded-full text-update transition-colors hover:bg-hover hover:text-ink"
+				className="no-drag relative flex h-6 w-6 shrink-0 items-center justify-center rounded-full text-ink transition-colors hover:bg-hover"
 				onClick={() => {
-					if (state.phase === "available") void getPi().checkForUpdates();
+					if (state.phase !== "available") return;
+					if (state.manual) void openReleasePage(state.version);
+					else void getPi().checkForUpdates();
 				}}
 			>
 				{state.phase === "downloading" ? (
@@ -75,7 +84,7 @@ export function UpdateButton() {
 					<DownloadIcon size={14} />
 				)}
 				{state.phase === "available" && (
-					<span className="absolute right-0.5 top-0.5 h-1.5 w-1.5 rounded-full bg-update ring-1 ring-canvas" />
+					<span className="absolute right-0.5 top-0.5 h-1.5 w-1.5 rounded-full bg-sky-400 ring-1 ring-canvas" />
 				)}
 			</button>
 		</Tooltip>

--- a/packages/desktop/src/renderer/src/components/settings/AboutPanel.tsx
+++ b/packages/desktop/src/renderer/src/components/settings/AboutPanel.tsx
@@ -25,12 +25,14 @@ export function AboutPanel() {
 		};
 	}, []);
 
-	// 状态行文案；downloaded 态按钮语义切换为「重启并安装」
+	// 状态行文案；downloaded 态按钮语义切换为「重启并安装」；manual 构建（mac 未正式签名）跳 release 页手动下载
 	const statusText =
 		state?.phase === "checking"
 			? t("update.checking")
 			: state?.phase === "available"
-				? t("update.available", { version: state.version })
+				? state.manual
+					? t("update.availableManual", { version: state.version })
+					: t("update.available", { version: state.version })
 				: state?.phase === "downloading"
 					? t("update.downloading", { percent: state.percent })
 					: state?.phase === "downloaded"
@@ -40,6 +42,18 @@ export function AboutPanel() {
 							: state?.phase === "error"
 								? t("update.checkFailed", { message: state.message })
 								: null;
+
+	const openReleasePage = async (version: string) => {
+		const appInfo = info ?? (await getPi().getAppInfo());
+		void getPi().openExternal(`${appInfo.repoUrl}/releases/tag/v${version}`);
+	};
+
+	const buttonLabel =
+		state?.phase === "downloaded"
+			? t("update.installNow")
+			: state?.phase === "available" && state.manual
+				? t("update.goDownload")
+				: t("update.checkForUpdates");
 
 	return (
 		<div className="flex flex-col items-center gap-1.5 py-10 text-center">
@@ -57,10 +71,11 @@ export function AboutPanel() {
 					className="rounded-lg border border-border px-4 py-1.5 text-[13px] text-ink-2 transition-colors hover:border-border-strong hover:bg-hover hover:text-ink"
 					onClick={() => {
 						if (state?.phase === "downloaded") void getPi().installUpdate();
+						else if (state?.phase === "available" && state.manual) void openReleasePage(state.version);
 						else void getPi().checkForUpdates();
 					}}
 				>
-					{state?.phase === "downloaded" ? t("update.installNow") : t("update.checkForUpdates")}
+					{buttonLabel}
 				</button>
 				<button
 					type="button"

--- a/packages/desktop/src/renderer/src/i18n/en.ts
+++ b/packages/desktop/src/renderer/src/i18n/en.ts
@@ -20,6 +20,8 @@ export const en: Messages = {
 		checkForUpdates: "Check for updates",
 		checking: "Checking for updates…",
 		available: "Version {version} available, click to download",
+		availableManual: "Version {version} available, click to open the download page",
+		goDownload: "Download",
 		downloading: "Downloading {percent}%",
 		downloaded: "Downloaded, installs on restart",
 		installNow: "Restart & install",

--- a/packages/desktop/src/renderer/src/i18n/zh.ts
+++ b/packages/desktop/src/renderer/src/i18n/zh.ts
@@ -18,6 +18,8 @@ export const zh = {
 		checkForUpdates: "检查更新",
 		checking: "正在检查更新…",
 		available: "发现新版本 {version}，点击下载",
+		availableManual: "发现新版本 {version}，点击前往下载页",
+		goDownload: "前往下载",
 		downloading: "下载中 {percent}%",
 		downloaded: "已下载，重启后安装",
 		installNow: "重启并安装",

--- a/packages/desktop/src/renderer/src/styles/globals.css
+++ b/packages/desktop/src/renderer/src/styles/globals.css
@@ -39,8 +39,9 @@
 	--color-on-ink: #ffffff;
 	--color-accent: #7c3aed;
 	--color-on-accent: #ffffff;
-	--color-update: #38bdf8;
-	--color-on-update: #0c4a6e;
+	/* 「重启」胶囊：很浅的蓝底 + 比背景深一档的中蓝字 */
+	--color-update: #e0f2fe;
+	--color-on-update: #0284c7;
 	/* 自定义背景图遮罩（rgb 分量；不透明度由 .app-bg-scrim 的 inline opacity 控制） */
 	--color-scrim: 250 250 250;
 	--markdown-code-bg: #f4f4f5;
@@ -72,8 +73,8 @@
 	--color-on-ink: #17171a;
 	--color-accent: #8b5cf6;
 	--color-on-accent: #ffffff;
-	--color-update: #38bdf8;
-	--color-on-update: #082f49;
+	--color-update: #0c4a6e;
+	--color-on-update: #7dd3fc;
 	--color-scrim: 23 23 26;
 	--markdown-code-bg: #2b2b31;
 	--markdown-code-text: #d4d4db;

--- a/packages/shared/src/update.ts
+++ b/packages/shared/src/update.ts
@@ -1,7 +1,9 @@
-/** 自动更新状态（main → renderer，update:event 通道） */
+/** 自动更新状态（main → renderer，update:event 通道）。
+    available 的 manual=true 表示当前构建无法自动安装（mac adhoc/未签名，Squirrel 签名校验不过），
+    renderer 不应触发下载，点击改为跳 GitHub release 页手动下载 */
 export type UpdateState =
 	| { phase: "checking" }
-	| { phase: "available"; version: string }
+	| { phase: "available"; version: string; manual: boolean }
 	| { phase: "not-available" }
 	| { phase: "downloading"; version: string; percent: number }
 	| { phase: "downloaded"; version: string }


### PR DESCRIPTION
## 背景
mac adhoc 签名构建下 Squirrel 强制签名校验，`quitAndInstall` 静默失败（日志实锤：Code signature did not pass validation），点「重启」无反应。

## 改动
- **manual 兜底**：`initUpdater` 启动时 `codesign -dv` 检测 adhoc/未签名 → `available` 事件带 `manual: true`，下载分支加守卫；UpdateButton/AboutPanel 点击改为跳 GitHub release 页（整条下载/进度/重启路径不出现）。正式签名后自动恢复正常路径
- **UI 配色**：下载图标/进度环改 `text-ink` 黑；重启胶囊改浅蓝底（#e0f2fe）+ 中蓝字（#0284c7）
- **Homebrew tap**：cask 模板 `packages/desktop/homebrew/pi-desktop.rb.template`；release.yml 新增 `tap` job（算 sha256 → 渲染模板 → push Jaxton07/homebrew-tap，用 secret TAP_GITHUB_TOKEN）
- i18n zh/en 新字符串（availableManual/goDownload）

tap 仓库已建好并播种 v0.2.0 cask，`brew fetch --cask jaxton07/tap/pi-desktop` 验证通过。

typecheck / lint / test 全绿。