### PR TITLE
feat: live activity indicator during tool/subagent execution (0.2.2)

### DIFF
--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@pi-desktop/desktop",
-	"version": "0.2.1",
+	"version": "0.2.2",
 	"private": true,
 	"description": "Desktop GUI for the Pi coding agent",
 	"author": "Jaxton07",

--- a/packages/desktop/src/renderer/src/components/chat/MessageList.tsx
+++ b/packages/desktop/src/renderer/src/components/chat/MessageList.tsx
@@ -4,6 +4,7 @@ import { useSessionsStore } from "../../stores/sessions";
 import { selectTranscript, useTranscriptStore } from "../../stores/transcript";
 import { MessageItem } from "./MessageItem";
 import { MetaGroup, type MetaItem } from "./MetaGroup";
+import { SubagentRunCard } from "./SubagentRunCard";
 
 /** 距底 ≤ 此值视为「在底部」，自动恢复跟随 */
 const BOTTOM_THRESHOLD = 48;
@@ -21,8 +22,14 @@ export function MessageList() {
 	const t = useT();
 	const activeSessionId = useSessionsStore((s) => s.activeSessionId);
 	const transcript = useTranscriptStore((s) => selectTranscript(s, activeSessionId));
-	/** agent 运行中且正文未出现（用户消息 → 下一次正文回复之间）→ 折叠组标题 working */
-	const agentWorking = transcript.agentActive && !transcript.streaming?.text;
+	const streaming = transcript.streaming;
+	/** 执行中的工具/子代理：工具执行发生在 message_end 之后、turn_end 之前，期间 streaming.text 仍在 */
+	const hasRunningWork = Boolean(
+		streaming?.tools.some((t) => t.state === "running") ||
+			streaming?.subagentRuns.some((r) => r.status === "running"),
+	);
+	/** agent 运行中且正文未出现 → 折叠组标题 working；正文已出但工具/子代理还在跑时不熄灯 */
+	const agentWorking = transcript.agentActive && (!streaming?.text || hasRunningWork);
 
 	const scrollRef = useRef<HTMLDivElement>(null);
 	const contentRef = useRef<HTMLDivElement>(null);
@@ -119,8 +126,7 @@ export function MessageList() {
 			items.push(<MessageItem key={message.id} message={message} metaInGroup />);
 		}
 	}
-	if (transcript.streaming) {
-		const streaming = transcript.streaming;
+	if (streaming) {
 		if (streaming.thinking || streaming.tools.length > 0) {
 			metaItems.push({
 				thinking: streaming.thinking,
@@ -146,12 +152,21 @@ export function MessageList() {
 				/>,
 			);
 		}
+		// 子代理运行中行：tool_execution_start 即入缓冲，流式期就展示（不等 turn_end 固化），顺序对齐固化后的 assistant → subagents
+		if (streaming.subagentRuns.length > 0) {
+			items.push(<SubagentRunCard key="streaming-subagents" runs={streaming.subagentRuns} />);
+		}
+	}
+	// 最新组无内容但仍在工作（正文已出、工具/子代理执行中）：挂上流式活动序列，预览行继续显示最新活动
+	if (metaItems.length === 0 && agentWorking && streaming && streaming.activity.length > 0) {
+		metaItems.push({ thinking: "", tools: [], activity: streaming.activity });
 	}
 	flushMeta(true, agentWorking);
 
 	return (
 		<div className="relative h-full">
-			<div ref={scrollRef} onScroll={handleScroll} className="h-full overflow-y-auto">
+			{/* overflow-x-hidden：任何行内容异常超宽都只裁剪，不产生页面级横向滚动条 */}
+			<div ref={scrollRef} onScroll={handleScroll} className="h-full overflow-x-hidden overflow-y-auto">
 				<div ref={contentRef} className="mx-auto flex max-w-[760px] flex-col gap-6 px-6 pt-8 pb-16">
 					{items}
 				</div>

--- a/packages/desktop/src/renderer/src/components/chat/MetaGroup.tsx
+++ b/packages/desktop/src/renderer/src/components/chat/MetaGroup.tsx
@@ -32,6 +32,23 @@ function ThinkingRow({ thinking }: { thinking: string }) {
 }
 /** working → worked 切换的缓冲时长：turn 间隙内不闪烁 */
 const HYSTERESIS_MS = 1500;
+/** 统一扫光周期（与 globals.css 的 shimmer-sweep 1.6s 一致） */
+const SWEEP_MS = 1600;
+const SWEEP_GRADIENT =
+	"linear-gradient(90deg, currentColor 40%, var(--shimmer-highlight) 50%, currentColor 60%)";
+
+/** 清除 rAF 扫光写在元素上的内联背景/填充样式（恢复常规文字颜色） */
+function clearSweepStyles(els: (HTMLElement | null)[]) {
+	for (const el of els) {
+		if (!el) continue;
+		el.style.backgroundImage = "";
+		el.style.backgroundSize = "";
+		el.style.backgroundPosition = "";
+		el.style.backgroundClip = "";
+		el.style.removeProperty("-webkit-background-clip");
+		el.style.removeProperty("-webkit-text-fill-color");
+	}
+}
 
 /**
  * 外层折叠组：聚合多条非正文消息的思考/工具，标题 = Working/Worked + 项目数
@@ -78,6 +95,59 @@ export function MetaGroup({
 		};
 	}, [working, shownWorking, endByText]);
 
+	const labelRef = useRef<HTMLSpanElement>(null);
+	const tickerWrapRef = useRef<HTMLDivElement>(null);
+
+	// 统一扫光：Working 标签与预览行工具名共享同一条光带（同一背景宽度+逐帧同步位移，
+	// 范围 = Working 左缘 → tool name 右缘；参数摘要保持实心不参与）。
+	// 纯 CSS 方案不可行：祖先 background-clip:text 会被 ticker 的 mask/transform 打断（子元素文字不渲染），
+	// 各自 shimmer-sweep 则是两条相位/宽度独立的光带
+	useEffect(() => {
+		if (!shownWorking) return;
+		if (window.matchMedia("(prefers-reduced-motion: reduce)").matches) return;
+		const label = labelRef.current;
+		if (!label) return;
+		let raf = 0;
+		const start = performance.now();
+		const tick = (now: number) => {
+			// 切换动画期间新旧两行并存：全部纳入（同 x 位置堆叠，范围不变，新行立即有扫光）
+			const nameEls = Array.from(
+				tickerWrapRef.current?.querySelectorAll<HTMLElement>("[data-shimmer-name]") ?? [],
+			);
+			const targets: HTMLElement[] = [label, ...nameEls];
+			const rects = targets.map((el) => el.getBoundingClientRect()).filter((r) => r.width > 0);
+			if (rects.length > 0) {
+				const left = Math.min(...rects.map((r) => r.left));
+				const right = Math.max(...rects.map((r) => r.right));
+				const w = Math.max(right - left, 1);
+				// 背景宽 2w，高光带中心在背景 50% 处；中心（range 相对坐标）从 -0.2w → 1.2w 单向循环
+				//（与 .shimmer-sweep 的 120%→-20% 同为左→右）；元素背景左缘 = centerRel - w - 元素在 range 内偏移
+				const progress = ((now - start) % SWEEP_MS) / SWEEP_MS;
+				const centerRel = -0.2 * w + progress * 1.4 * w;
+				for (let i = 0; i < targets.length; i++) {
+					const el = targets[i];
+					const rect = el.getBoundingClientRect();
+					if (rect.width === 0) continue;
+					el.style.backgroundImage = SWEEP_GRADIENT;
+					el.style.backgroundSize = `${w * 2}px 100%`;
+					el.style.backgroundPosition = `${centerRel - w - (rect.left - left)}px 0px`;
+					el.style.backgroundClip = "text";
+					el.style.setProperty("-webkit-background-clip", "text");
+					el.style.setProperty("-webkit-text-fill-color", "transparent");
+				}
+			}
+			raf = requestAnimationFrame(tick);
+		};
+		raf = requestAnimationFrame(tick);
+		return () => {
+			cancelAnimationFrame(raf);
+			clearSweepStyles([
+				labelRef.current,
+				...Array.from(tickerWrapRef.current?.querySelectorAll<HTMLElement>("[data-shimmer-name]") ?? []),
+			]);
+		};
+	}, [shownWorking]);
+
 	const rows = items.flatMap((item, i) => [
 		// biome-ignore lint/suspicious/noArrayIndexKey: 折叠组内项无独立 id，列表顺序稳定
 		item.thinking ? <ThinkingRow key={`thinking-${i}`} thinking={item.thinking} /> : null,
@@ -108,23 +178,26 @@ export function MetaGroup({
 	return (
 		// -mb-3：抵消 MessageList gap-6 的一部分，状态行与后续正文/消息间距收紧
 		<div className="-mb-3">
+			{/* min-h-6：与内联预览行（h-6）等高，working/worked 切换行高不变 */}
 			<details className="group/outer peer">
-				<summary className="group/row flex cursor-pointer items-center gap-2 py-0.5 select-none [&::-webkit-details-marker]:hidden">
+				<summary className="group/row flex min-h-6 cursor-pointer items-center gap-2 py-0.5 select-none [&::-webkit-details-marker]:hidden">
 					<span
-						className={`shrink-0 text-[13px] font-bold transition-colors ${
-							shownWorking ? "shimmer-sweep text-ink-dim" : "text-ink-dim group-hover/row:text-ink"
-						}`}
+						ref={labelRef}
+						className="shrink-0 text-[13px] font-bold text-ink-dim transition-colors group-hover/row:text-ink"
 					>
 						{t(shownWorking ? "message.working" : "message.worked")}
 						{count > 0 && <span className="ml-1 font-normal text-ink-faint">· {count}</span>}
 					</span>
+					{/* 实时预览内联进标题行（单行截断，展开组时隐藏）：工作中与完成后恒为一行高，消除布局抖动 */}
+					{shownWorking && (
+						<div ref={tickerWrapRef} className="min-w-0 flex-1 group-open/outer:hidden">
+							<PreviewTicker items={liveItems} reserveSpace />
+						</div>
+					)}
 					<ExpandArrowIcon className="shrink-0 text-ink-faint opacity-0 transition-[opacity,transform,color] group-hover/row:opacity-100 group-hover/row:text-ink-2 group-open/outer:rotate-90" />
 				</summary>
 				<div className="flex flex-col gap-1.5 py-1">{rows}</div>
 			</details>
-			<div className="peer-[[open]]:hidden">
-				{shownWorking && <PreviewTicker items={liveItems} reserveSpace />}
-			</div>
 		</div>
 	);
 }

--- a/packages/desktop/src/renderer/src/components/chat/MetaGroup.tsx
+++ b/packages/desktop/src/renderer/src/components/chat/MetaGroup.tsx
@@ -124,8 +124,7 @@ export function MetaGroup({
 				//（与 .shimmer-sweep 的 120%→-20% 同为左→右）；元素背景左缘 = centerRel - w - 元素在 range 内偏移
 				const progress = ((now - start) % SWEEP_MS) / SWEEP_MS;
 				const centerRel = -0.2 * w + progress * 1.4 * w;
-				for (let i = 0; i < targets.length; i++) {
-					const el = targets[i];
+				for (const el of targets) {
 					const rect = el.getBoundingClientRect();
 					if (rect.width === 0) continue;
 					el.style.backgroundImage = SWEEP_GRADIENT;

--- a/packages/desktop/src/renderer/src/components/chat/PreviewTicker.tsx
+++ b/packages/desktop/src/renderer/src/components/chat/PreviewTicker.tsx
@@ -26,12 +26,14 @@ function ThinkingPreviewRow() {
 	);
 }
 
-/** tool 预览行：工具名 + 参数摘要（单行截断），不可展开；参数随流式增长原地更新 */
+/** tool 预览行：工具名（data-shimmer-name：MetaGroup 统一扫光的范围终点）+ 参数摘要（单行截断），不可展开；参数随流式增长原地更新 */
 function ToolPreviewRow({ name, args }: { name: string; args: string }) {
 	const summary = summarizeArgs(args);
 	return (
 		<div className="flex items-center gap-2 py-0.5">
-			<span className="shrink-0 font-mono text-[13px] font-semibold text-ink-dim">{displayName(name)}</span>
+			<span data-shimmer-name className="shrink-0 font-mono text-[13px] font-semibold text-ink-dim">
+				{displayName(name)}
+			</span>
 			{summary && (
 				<span className="min-w-0 flex-1 truncate font-mono text-[12px] text-ink-faint">{summary}</span>
 			)}

--- a/packages/desktop/src/renderer/src/components/chat/ToolCallCard.tsx
+++ b/packages/desktop/src/renderer/src/components/chat/ToolCallCard.tsx
@@ -33,7 +33,8 @@ export function ToolCallCard({ tool }: { tool: UIToolCall }) {
 	const textRef = useRef<HTMLSpanElement>(null);
 	const rowRef = useRef<HTMLElement>(null);
 
-	// args 在工具调用创建后不变，只测量一次 + 监听行宽变化
+	// 挂载时 args 可能为空（流式 toolcall，textRef 未渲染）→ 随 summary 变化重测；
+	// overflow:hidden 下 scrollWidth 恒为内容全宽，收缩后重测结果依然正确
 	useEffect(() => {
 		const check = () => {
 			const el = textRef.current;
@@ -48,10 +49,12 @@ export function ToolCallCard({ tool }: { tool: UIToolCall }) {
 		const ro = new ResizeObserver(check);
 		ro.observe(row);
 		return () => ro.disconnect();
-	}, []);
+	}, [summary]);
 
-	const nameClass =
-		"shrink-0 font-mono text-[13px] font-semibold text-ink-dim transition-colors group-hover/row:text-ink";
+	// running 时工具名加高光扫过动画（与 MetaGroup 的 Working 标题同款 shimmer-sweep）
+	const nameClass = `shrink-0 font-mono text-[13px] font-semibold text-ink-dim transition-colors group-hover/row:text-ink${
+		tool.state === "running" ? " shimmer-sweep" : ""
+	}`;
 	const summaryClass =
 		"relative overflow-hidden whitespace-nowrap font-mono text-[12px] text-ink-faint transition-colors group-hover/row:text-ink";
 

--- a/packages/desktop/src/renderer/src/components/chat/ToolCallCard.tsx
+++ b/packages/desktop/src/renderer/src/components/chat/ToolCallCard.tsx
@@ -35,6 +35,7 @@ export function ToolCallCard({ tool }: { tool: UIToolCall }) {
 
 	// 挂载时 args 可能为空（流式 toolcall，textRef 未渲染）→ 随 summary 变化重测；
 	// overflow:hidden 下 scrollWidth 恒为内容全宽，收缩后重测结果依然正确
+	// biome-ignore lint/correctness/useExhaustiveDependencies: summary 是刻意的重跑触发器（effect 内只读 ref，args 流式增长时需重测）
 	useEffect(() => {
 		const check = () => {
 			const el = textRef.current;


### PR DESCRIPTION
## 改动

测试中发现的体验问题：agent 执行后台工具（Bash/子代理）时 UI 无任何状态提示，看起来像卡住。

### 根因
- 工具执行发生在 message_end 之后、turn_end 之前，期间 streaming.text 仍在 → working 信号被正文提前熄灭
- subagent 工具在 tool_execution_start 时被移出折叠区，但 subagentRuns 缓冲要等 turn_end 才渲染 → 执行期间完全无感知
- 长命令省略失效：ToolCallCard 测量 effect 只在挂载时跑一次，流式工具挂载时 args 为空导致永远不重测

### 修复
- working 信号 = agentActive 且（无流式正文 或 有执行中工具/子代理），执行期间状态行保持 Working + 预览行
- subagent 运行中行流式期即渲染（呼吸点 + 名称）
- 省略测量随 summary 变化重测；滚动容器 overflow-x 兜底防横向滚动条
- 预览行内联进 Working 标题行（消除布局抖动）
- 统一扫光：rAF 同步一张背景，一条光带从 Working 扫到 tool name 末尾（祖先 background-clip:text 会被 ticker mask/transform 打断，纯 CSS 方案不可行，已用无头浏览器验证）