### PR TITLE
feat: 顶栏会话胶囊拖拽排序（浏览器标签式）

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -952,6 +952,73 @@
 				"node": ">=14.21.3"
 			}
 		},
+		"node_modules/@dnd-kit/accessibility": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmmirror.com/@dnd-kit/accessibility/-/accessibility-3.1.1.tgz",
+			"integrity": "sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==",
+			"license": "MIT",
+			"dependencies": {
+				"tslib": "^2.0.0"
+			},
+			"peerDependencies": {
+				"react": ">=16.8.0"
+			}
+		},
+		"node_modules/@dnd-kit/core": {
+			"version": "6.3.1",
+			"resolved": "https://registry.npmmirror.com/@dnd-kit/core/-/core-6.3.1.tgz",
+			"integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@dnd-kit/accessibility": "^3.1.1",
+				"@dnd-kit/utilities": "^3.2.2",
+				"tslib": "^2.0.0"
+			},
+			"peerDependencies": {
+				"react": ">=16.8.0",
+				"react-dom": ">=16.8.0"
+			}
+		},
+		"node_modules/@dnd-kit/modifiers": {
+			"version": "9.0.0",
+			"resolved": "https://registry.npmmirror.com/@dnd-kit/modifiers/-/modifiers-9.0.0.tgz",
+			"integrity": "sha512-ybiLc66qRGuZoC20wdSSG6pDXFikui/dCNGthxv4Ndy8ylErY0N3KVxY2bgo7AWwIbxDmXDg3ylAFmnrjcbVvw==",
+			"license": "MIT",
+			"dependencies": {
+				"@dnd-kit/utilities": "^3.2.2",
+				"tslib": "^2.0.0"
+			},
+			"peerDependencies": {
+				"@dnd-kit/core": "^6.3.0",
+				"react": ">=16.8.0"
+			}
+		},
+		"node_modules/@dnd-kit/sortable": {
+			"version": "10.0.0",
+			"resolved": "https://registry.npmmirror.com/@dnd-kit/sortable/-/sortable-10.0.0.tgz",
+			"integrity": "sha512-+xqhmIIzvAYMGfBYYnbKuNicfSsk4RksY2XdmJhT+HAC01nix6fHCztU68jooFiMUB01Ky3F0FyOvhG/BZrWkg==",
+			"license": "MIT",
+			"dependencies": {
+				"@dnd-kit/utilities": "^3.2.2",
+				"tslib": "^2.0.0"
+			},
+			"peerDependencies": {
+				"@dnd-kit/core": "^6.3.0",
+				"react": ">=16.8.0"
+			}
+		},
+		"node_modules/@dnd-kit/utilities": {
+			"version": "3.2.2",
+			"resolved": "https://registry.npmmirror.com/@dnd-kit/utilities/-/utilities-3.2.2.tgz",
+			"integrity": "sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==",
+			"license": "MIT",
+			"dependencies": {
+				"tslib": "^2.0.0"
+			},
+			"peerDependencies": {
+				"react": ">=16.8.0"
+			}
+		},
 		"node_modules/@earendil-works/pi-ai": {
 			"version": "0.84.0",
 			"resolved": "https://registry.npmmirror.com/@earendil-works/pi-ai/-/pi-ai-0.84.0.tgz",
@@ -10435,6 +10502,9 @@
 			"version": "0.3.5",
 			"license": "MIT",
 			"dependencies": {
+				"@dnd-kit/core": "^6.3.1",
+				"@dnd-kit/modifiers": "^9.0.0",
+				"@dnd-kit/sortable": "^10.0.0",
 				"@earendil-works/pi-ai": "0.84.0",
 				"@earendil-works/pi-coding-agent": "0.84.0",
 				"@percho/backend": "*",

--- a/package-lock.json
+++ b/package-lock.json
@@ -4431,6 +4431,146 @@
 				"win32"
 			]
 		},
+		"node_modules/@shikijs/core": {
+			"version": "4.4.3",
+			"resolved": "https://registry.npmmirror.com/@shikijs/core/-/core-4.4.3.tgz",
+			"integrity": "sha512-QCR4q2ZO/ILJEuwiBMel4wdcTDb1JGwfjKTxPDF6x8ixOaluPrVqIn06C99AcRPhmYlBR56d/Fb+GN58GzExpg==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@shikijs/primitive": "4.4.3",
+				"@shikijs/types": "4.4.3",
+				"@shikijs/vscode-textmate": "^10.0.2",
+				"@types/hast": "^3.0.5",
+				"hast-util-to-html": "^9.0.5"
+			},
+			"engines": {
+				"node": ">=20"
+			}
+		},
+		"node_modules/@shikijs/engine-javascript": {
+			"version": "4.4.3",
+			"resolved": "https://registry.npmmirror.com/@shikijs/engine-javascript/-/engine-javascript-4.4.3.tgz",
+			"integrity": "sha512-FbOjFJp9VLdo1Wevs10BBtVxiTWwNLqZh5Gkhjgda/ioL15YOgeSl9n+6XMa3qRlPQzfhFNe641SrynFHYG0nQ==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@shikijs/types": "4.4.3",
+				"@shikijs/vscode-textmate": "^10.0.2",
+				"oniguruma-to-es": "^4.3.6"
+			},
+			"engines": {
+				"node": ">=20"
+			}
+		},
+		"node_modules/@shikijs/engine-oniguruma": {
+			"version": "4.4.3",
+			"resolved": "https://registry.npmmirror.com/@shikijs/engine-oniguruma/-/engine-oniguruma-4.4.3.tgz",
+			"integrity": "sha512-EcOQkxdxGQrc1Row/cC2c96/v1dbZqGnEVu1qTuT/MJmp6+cXCvQussowVmCv5Tqr3KuY3c7IbM6HTW3LJ1k9w==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@shikijs/types": "4.4.3",
+				"@shikijs/vscode-textmate": "^10.0.2"
+			},
+			"engines": {
+				"node": ">=20"
+			}
+		},
+		"node_modules/@shikijs/langs": {
+			"version": "4.4.3",
+			"resolved": "https://registry.npmmirror.com/@shikijs/langs/-/langs-4.4.3.tgz",
+			"integrity": "sha512-ePic0yfAJGOF83D5wBHK/00EjK65oahBYxFk5epgq33WRv7X9UuxLEV8PtR0szC0z8dl7INIpIodB99JRFlR+A==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@shikijs/types": "4.4.3"
+			},
+			"engines": {
+				"node": ">=20"
+			}
+		},
+		"node_modules/@shikijs/monaco": {
+			"version": "3.23.0",
+			"resolved": "https://registry.npmmirror.com/@shikijs/monaco/-/monaco-3.23.0.tgz",
+			"integrity": "sha512-OCApTdAGTHMFUXSYwGztW6EnlxXsWNrpnGf+uO+AznE+khC6V1/8QjuJESIcvZUIq9iAp4ZCNYosZKSVj1Hctg==",
+			"license": "MIT",
+			"dependencies": {
+				"@shikijs/core": "3.23.0",
+				"@shikijs/types": "3.23.0",
+				"@shikijs/vscode-textmate": "^10.0.2"
+			}
+		},
+		"node_modules/@shikijs/monaco/node_modules/@shikijs/core": {
+			"version": "3.23.0",
+			"resolved": "https://registry.npmmirror.com/@shikijs/core/-/core-3.23.0.tgz",
+			"integrity": "sha512-NSWQz0riNb67xthdm5br6lAkvpDJRTgB36fxlo37ZzM2yq0PQFFzbd8psqC2XMPgCzo1fW6cVi18+ArJ44wqgA==",
+			"license": "MIT",
+			"dependencies": {
+				"@shikijs/types": "3.23.0",
+				"@shikijs/vscode-textmate": "^10.0.2",
+				"@types/hast": "^3.0.4",
+				"hast-util-to-html": "^9.0.5"
+			}
+		},
+		"node_modules/@shikijs/monaco/node_modules/@shikijs/types": {
+			"version": "3.23.0",
+			"resolved": "https://registry.npmmirror.com/@shikijs/types/-/types-3.23.0.tgz",
+			"integrity": "sha512-3JZ5HXOZfYjsYSk0yPwBrkupyYSLpAE26Qc0HLghhZNGTZg/SKxXIIgoxOpmmeQP0RRSDJTk1/vPfw9tbw+jSQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@shikijs/vscode-textmate": "^10.0.2",
+				"@types/hast": "^3.0.4"
+			}
+		},
+		"node_modules/@shikijs/primitive": {
+			"version": "4.4.3",
+			"resolved": "https://registry.npmmirror.com/@shikijs/primitive/-/primitive-4.4.3.tgz",
+			"integrity": "sha512-m0wBeLDQDeIxRdUmrCPdQqfuUamDwRL5isCfYbguKD6NiaKpVbsv+3J81DyIKgNW5h4WAIIr8T4EkgQrBBxvaQ==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@shikijs/types": "4.4.3",
+				"@shikijs/vscode-textmate": "^10.0.2",
+				"@types/hast": "^3.0.5"
+			},
+			"engines": {
+				"node": ">=20"
+			}
+		},
+		"node_modules/@shikijs/themes": {
+			"version": "4.4.3",
+			"resolved": "https://registry.npmmirror.com/@shikijs/themes/-/themes-4.4.3.tgz",
+			"integrity": "sha512-w8UHjeUnIR965KMWJHUPXOc2mNJUnK3vpVLYLvw5IYU2mnTTJ89E24OrJDBNiJDQ0qzb0tc4l7mrIXx5cFeIyw==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@shikijs/types": "4.4.3"
+			},
+			"engines": {
+				"node": ">=20"
+			}
+		},
+		"node_modules/@shikijs/types": {
+			"version": "4.4.3",
+			"resolved": "https://registry.npmmirror.com/@shikijs/types/-/types-4.4.3.tgz",
+			"integrity": "sha512-UEJxmRR++MAGR6hugn0vgVS2W/6lWAts84FFSrnlH9sP0LNol7E5+NQ792pH8liWUhyMyjhTgSUH3k7iD7tc5g==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@shikijs/vscode-textmate": "^10.0.2",
+				"@types/hast": "^3.0.5"
+			},
+			"engines": {
+				"node": ">=20"
+			}
+		},
+		"node_modules/@shikijs/vscode-textmate": {
+			"version": "10.0.2",
+			"resolved": "https://registry.npmmirror.com/@shikijs/vscode-textmate/-/vscode-textmate-10.0.2.tgz",
+			"integrity": "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==",
+			"license": "MIT"
+		},
 		"node_modules/@sindresorhus/is": {
 			"version": "4.6.0",
 			"resolved": "https://registry.npmmirror.com/@sindresorhus/is/-/is-4.6.0.tgz",
@@ -4963,6 +5103,15 @@
 				"@types/node": "*"
 			}
 		},
+		"node_modules/@types/hast": {
+			"version": "3.0.5",
+			"resolved": "https://registry.npmmirror.com/@types/hast/-/hast-3.0.5.tgz",
+			"integrity": "sha512-rp/ezSWaD1m44dPKICGhiskI13nVr7qTloFwDa/IYkhhf5nzwP+zIQcIJh3WIFSBOy/H1PzB40jPjMDksN4F+g==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/unist": "*"
+			}
+		},
 		"node_modules/@types/http-cache-semantics": {
 			"version": "4.2.0",
 			"resolved": "https://registry.npmmirror.com/@types/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
@@ -4978,6 +5127,15 @@
 			"license": "MIT",
 			"dependencies": {
 				"@types/node": "*"
+			}
+		},
+		"node_modules/@types/mdast": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmmirror.com/@types/mdast/-/mdast-4.0.4.tgz",
+			"integrity": "sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/unist": "*"
 			}
 		},
 		"node_modules/@types/ms": {
@@ -5031,6 +5189,25 @@
 			"resolved": "https://registry.npmmirror.com/@types/retry/-/retry-0.12.0.tgz",
 			"integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==",
 			"license": "MIT"
+		},
+		"node_modules/@types/trusted-types": {
+			"version": "2.0.7",
+			"resolved": "https://registry.npmmirror.com/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+			"integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+			"license": "MIT",
+			"optional": true
+		},
+		"node_modules/@types/unist": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmmirror.com/@types/unist/-/unist-3.0.3.tgz",
+			"integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
+			"license": "MIT"
+		},
+		"node_modules/@ungap/structured-clone": {
+			"version": "1.3.3",
+			"resolved": "https://registry.npmmirror.com/@ungap/structured-clone/-/structured-clone-1.3.3.tgz",
+			"integrity": "sha512-60YRaenCQcVjYEKOcG824+DRGGIQ3VKErcBoAEDJZz5bKIs2ZG+X/H9Nk+Q6EVkwJk5QNApxbrc5QtBSwtrXAg==",
+			"license": "ISC"
 		},
 		"node_modules/@vitejs/plugin-react": {
 			"version": "5.2.0",
@@ -5213,6 +5390,12 @@
 				"type": "github",
 				"url": "https://github.com/sponsors/epoberezkin"
 			}
+		},
+		"node_modules/alien-signals": {
+			"version": "2.0.8",
+			"resolved": "https://registry.npmmirror.com/alien-signals/-/alien-signals-2.0.8.tgz",
+			"integrity": "sha512-844G1VLkk0Pe2SJjY0J8vp8ADI73IM4KliNu2OGlYzWpO28NexEUvjHTcFjFX3VXoiUtwTbHxLNI9ImkcoBqzA==",
+			"license": "MIT"
 		},
 		"node_modules/ansi-regex": {
 			"version": "5.0.1",
@@ -5732,6 +5915,16 @@
 			],
 			"license": "CC-BY-4.0"
 		},
+		"node_modules/ccount": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmmirror.com/ccount/-/ccount-2.0.1.tgz",
+			"integrity": "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==",
+			"license": "MIT",
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/wooorm"
+			}
+		},
 		"node_modules/chai": {
 			"version": "5.3.3",
 			"resolved": "https://registry.npmmirror.com/chai/-/chai-5.3.3.tgz",
@@ -5764,6 +5957,26 @@
 			},
 			"funding": {
 				"url": "https://github.com/chalk/chalk?sponsor=1"
+			}
+		},
+		"node_modules/character-entities-html4": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmmirror.com/character-entities-html4/-/character-entities-html4-2.1.0.tgz",
+			"integrity": "sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==",
+			"license": "MIT",
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/wooorm"
+			}
+		},
+		"node_modules/character-entities-legacy": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmmirror.com/character-entities-legacy/-/character-entities-legacy-3.0.0.tgz",
+			"integrity": "sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==",
+			"license": "MIT",
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/wooorm"
 			}
 		},
 		"node_modules/check-error": {
@@ -5877,6 +6090,16 @@
 			},
 			"engines": {
 				"node": ">= 0.8"
+			}
+		},
+		"node_modules/comma-separated-tokens": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmmirror.com/comma-separated-tokens/-/comma-separated-tokens-2.0.3.tgz",
+			"integrity": "sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==",
+			"license": "MIT",
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/wooorm"
 			}
 		},
 		"node_modules/commander": {
@@ -6097,6 +6320,15 @@
 				"node": ">=0.4.0"
 			}
 		},
+		"node_modules/dequal": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmmirror.com/dequal/-/dequal-2.0.3.tgz",
+			"integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=6"
+			}
+		},
 		"node_modules/detect-libc": {
 			"version": "2.1.2",
 			"resolved": "https://registry.npmmirror.com/detect-libc/-/detect-libc-2.1.2.tgz",
@@ -6114,6 +6346,19 @@
 			"dev": true,
 			"license": "MIT",
 			"optional": true
+		},
+		"node_modules/devlop": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmmirror.com/devlop/-/devlop-1.1.0.tgz",
+			"integrity": "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==",
+			"license": "MIT",
+			"dependencies": {
+				"dequal": "^2.0.0"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/wooorm"
+			}
 		},
 		"node_modules/dir-compare": {
 			"version": "4.2.0",
@@ -6168,6 +6413,15 @@
 				"builder-util": "26.15.3",
 				"fs-extra": "^10.1.0",
 				"js-yaml": "^4.1.0"
+			}
+		},
+		"node_modules/dompurify": {
+			"version": "3.2.7",
+			"resolved": "https://registry.npmmirror.com/dompurify/-/dompurify-3.2.7.tgz",
+			"integrity": "sha512-WhL/YuveyGXJaerVlMYGWhvQswa7myDG17P7Vu65EWC05o8vfeNbvNf4d/BOvH99+ZW+LlQsc1GDKMa1vNK6dw==",
+			"license": "(MPL-2.0 OR Apache-2.0)",
+			"optionalDependencies": {
+				"@types/trusted-types": "^2.0.7"
 			}
 		},
 		"node_modules/dotenv": {
@@ -7200,6 +7454,42 @@
 				"node": ">= 0.4"
 			}
 		},
+		"node_modules/hast-util-to-html": {
+			"version": "9.0.5",
+			"resolved": "https://registry.npmmirror.com/hast-util-to-html/-/hast-util-to-html-9.0.5.tgz",
+			"integrity": "sha512-OguPdidb+fbHQSU4Q4ZiLKnzWo8Wwsf5bZfbvu7//a9oTYoqD/fWpe96NuHkoS9h0ccGOTe0C4NGXdtS0iObOw==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/hast": "^3.0.0",
+				"@types/unist": "^3.0.0",
+				"ccount": "^2.0.0",
+				"comma-separated-tokens": "^2.0.0",
+				"hast-util-whitespace": "^3.0.0",
+				"html-void-elements": "^3.0.0",
+				"mdast-util-to-hast": "^13.0.0",
+				"property-information": "^7.0.0",
+				"space-separated-tokens": "^2.0.0",
+				"stringify-entities": "^4.0.0",
+				"zwitch": "^2.0.4"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/hast-util-whitespace": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmmirror.com/hast-util-whitespace/-/hast-util-whitespace-3.0.0.tgz",
+			"integrity": "sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/hast": "^3.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
 		"node_modules/hosted-git-info": {
 			"version": "4.1.0",
 			"resolved": "https://registry.npmmirror.com/hosted-git-info/-/hosted-git-info-4.1.0.tgz",
@@ -7232,6 +7522,16 @@
 			"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
 			"dev": true,
 			"license": "ISC"
+		},
+		"node_modules/html-void-elements": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmmirror.com/html-void-elements/-/html-void-elements-3.0.0.tgz",
+			"integrity": "sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==",
+			"license": "MIT",
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/wooorm"
+			}
 		},
 		"node_modules/http-cache-semantics": {
 			"version": "4.2.0",
@@ -7927,6 +8227,18 @@
 				"node": ">=20.19"
 			}
 		},
+		"node_modules/marked": {
+			"version": "14.0.0",
+			"resolved": "https://registry.npmmirror.com/marked/-/marked-14.0.0.tgz",
+			"integrity": "sha512-uIj4+faQ+MgHgwUW1l2PsPglZLOLOT1uErt06dAPtx2kjteLAkbsd/0FiYg/MGS+i7ZKLb7w2WClxHkzOOuryQ==",
+			"license": "MIT",
+			"bin": {
+				"marked": "bin/marked.js"
+			},
+			"engines": {
+				"node": ">= 18"
+			}
+		},
 		"node_modules/markstream-core": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmmirror.com/markstream-core/-/markstream-core-1.0.3.tgz",
@@ -7999,10 +8311,120 @@
 				"node": ">= 0.4"
 			}
 		},
+		"node_modules/mdast-util-to-hast": {
+			"version": "13.2.1",
+			"resolved": "https://registry.npmmirror.com/mdast-util-to-hast/-/mdast-util-to-hast-13.2.1.tgz",
+			"integrity": "sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/hast": "^3.0.0",
+				"@types/mdast": "^4.0.0",
+				"@ungap/structured-clone": "^1.0.0",
+				"devlop": "^1.0.0",
+				"micromark-util-sanitize-uri": "^2.0.0",
+				"trim-lines": "^3.0.0",
+				"unist-util-position": "^5.0.0",
+				"unist-util-visit": "^5.0.0",
+				"vfile": "^6.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
 		"node_modules/mdurl": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmmirror.com/mdurl/-/mdurl-2.1.0.tgz",
 			"integrity": "sha512-1+HBaOx0zi/dQWht8rNv9MYf9qqpqL/kxI0hXImU6Y547zM6Sni8BQibt7ifgMcYtQg41ao3Ivd6cnSM86inpg==",
+			"license": "MIT"
+		},
+		"node_modules/micromark-util-character": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmmirror.com/micromark-util-character/-/micromark-util-character-2.1.1.tgz",
+			"integrity": "sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==",
+			"funding": [
+				{
+					"type": "GitHub Sponsors",
+					"url": "https://github.com/sponsors/unifiedjs"
+				},
+				{
+					"type": "OpenCollective",
+					"url": "https://opencollective.com/unified"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"micromark-util-symbol": "^2.0.0",
+				"micromark-util-types": "^2.0.0"
+			}
+		},
+		"node_modules/micromark-util-encode": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmmirror.com/micromark-util-encode/-/micromark-util-encode-2.0.1.tgz",
+			"integrity": "sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==",
+			"funding": [
+				{
+					"type": "GitHub Sponsors",
+					"url": "https://github.com/sponsors/unifiedjs"
+				},
+				{
+					"type": "OpenCollective",
+					"url": "https://opencollective.com/unified"
+				}
+			],
+			"license": "MIT"
+		},
+		"node_modules/micromark-util-sanitize-uri": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmmirror.com/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-2.0.1.tgz",
+			"integrity": "sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==",
+			"funding": [
+				{
+					"type": "GitHub Sponsors",
+					"url": "https://github.com/sponsors/unifiedjs"
+				},
+				{
+					"type": "OpenCollective",
+					"url": "https://opencollective.com/unified"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"micromark-util-character": "^2.0.0",
+				"micromark-util-encode": "^2.0.0",
+				"micromark-util-symbol": "^2.0.0"
+			}
+		},
+		"node_modules/micromark-util-symbol": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmmirror.com/micromark-util-symbol/-/micromark-util-symbol-2.0.1.tgz",
+			"integrity": "sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==",
+			"funding": [
+				{
+					"type": "GitHub Sponsors",
+					"url": "https://github.com/sponsors/unifiedjs"
+				},
+				{
+					"type": "OpenCollective",
+					"url": "https://opencollective.com/unified"
+				}
+			],
+			"license": "MIT"
+		},
+		"node_modules/micromark-util-types": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmmirror.com/micromark-util-types/-/micromark-util-types-2.0.2.tgz",
+			"integrity": "sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==",
+			"funding": [
+				{
+					"type": "GitHub Sponsors",
+					"url": "https://github.com/sponsors/unifiedjs"
+				},
+				{
+					"type": "OpenCollective",
+					"url": "https://opencollective.com/unified"
+				}
+			],
 			"license": "MIT"
 		},
 		"node_modules/mime": {
@@ -8112,6 +8534,16 @@
 			},
 			"bin": {
 				"mkdirp": "bin/cmd.js"
+			}
+		},
+		"node_modules/monaco-editor": {
+			"version": "0.55.1",
+			"resolved": "https://registry.npmmirror.com/monaco-editor/-/monaco-editor-0.55.1.tgz",
+			"integrity": "sha512-jz4x+TJNFHwHtwuV9vA9rMujcZRb0CEilTEwG2rRSpe/A7Jdkuj8xPKttCgOh+v/lkHy7HsZ64oj+q3xoAFl9A==",
+			"license": "MIT",
+			"dependencies": {
+				"dompurify": "3.2.7",
+				"marked": "14.0.0"
 			}
 		},
 		"node_modules/ms": {
@@ -8375,6 +8807,23 @@
 			"license": "ISC",
 			"dependencies": {
 				"wrappy": "1"
+			}
+		},
+		"node_modules/oniguruma-parser": {
+			"version": "0.12.2",
+			"resolved": "https://registry.npmmirror.com/oniguruma-parser/-/oniguruma-parser-0.12.2.tgz",
+			"integrity": "sha512-6HVa5oIrgMC6aA6WF6XyyqbhRPJrKR02L20+2+zpDtO5QAzGHAUGw5TKQvwi5vctNnRHkJYmjAhRVQF2EKdTQw==",
+			"license": "MIT"
+		},
+		"node_modules/oniguruma-to-es": {
+			"version": "4.3.6",
+			"resolved": "https://registry.npmmirror.com/oniguruma-to-es/-/oniguruma-to-es-4.3.6.tgz",
+			"integrity": "sha512-csuQ9x3Yr0cEIs/Zgx/OEt9iBw9vqIunAPQkx19R/fiMq2oGVTgcMqO/V3Ybqefr1TBvosI6jU539ksaBULJyA==",
+			"license": "MIT",
+			"dependencies": {
+				"oniguruma-parser": "^0.12.2",
+				"regex": "^6.1.0",
+				"regex-recursion": "^6.0.2"
 			}
 		},
 		"node_modules/openai": {
@@ -8682,6 +9131,16 @@
 				"signal-exit": "^3.0.2"
 			}
 		},
+		"node_modules/property-information": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmmirror.com/property-information/-/property-information-7.2.0.tgz",
+			"integrity": "sha512-IAtzIB6sUiWaJYrX9smp3V46pBGbBeLFRGdh25kg1334VcBlD8HzhPeNIWQH9zhGmo2itIe25EHt9dQP7G5hmg==",
+			"license": "MIT",
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/wooorm"
+			}
+		},
 		"node_modules/protobufjs": {
 			"version": "7.6.5",
 			"resolved": "https://registry.npmmirror.com/protobufjs/-/protobufjs-7.6.5.tgz",
@@ -8817,6 +9276,30 @@
 				"string_decoder": "~1.1.1",
 				"util-deprecate": "~1.0.1"
 			}
+		},
+		"node_modules/regex": {
+			"version": "6.1.0",
+			"resolved": "https://registry.npmmirror.com/regex/-/regex-6.1.0.tgz",
+			"integrity": "sha512-6VwtthbV4o/7+OaAF9I5L5V3llLEsoPyq9P1JVXkedTP33c7MfCG0/5NOPcSJn0TzXcG9YUrR0gQSWioew3LDg==",
+			"license": "MIT",
+			"dependencies": {
+				"regex-utilities": "^2.3.0"
+			}
+		},
+		"node_modules/regex-recursion": {
+			"version": "6.0.2",
+			"resolved": "https://registry.npmmirror.com/regex-recursion/-/regex-recursion-6.0.2.tgz",
+			"integrity": "sha512-0YCaSCq2VRIebiaUviZNs0cBz1kg5kVS2UKUfNIx8YVs1cN3AV7NTctO5FOKBA+UT2BPJIWZauYHPqJODG50cg==",
+			"license": "MIT",
+			"dependencies": {
+				"regex-utilities": "^2.3.0"
+			}
+		},
+		"node_modules/regex-utilities": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmmirror.com/regex-utilities/-/regex-utilities-2.3.0.tgz",
+			"integrity": "sha512-8VhliFJAWRaUiVvREIiW2NXXTmHs4vMNnSzuJVhscgmGav3g9VDxLrQndI3dZZVVdp0ZO/5v0xmX516/7M9cng==",
+			"license": "MIT"
 		},
 		"node_modules/require-directory": {
 			"version": "2.1.1",
@@ -9055,6 +9538,76 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/shiki": {
+			"version": "4.4.3",
+			"resolved": "https://registry.npmmirror.com/shiki/-/shiki-4.4.3.tgz",
+			"integrity": "sha512-Mb/GvXPHBAXdgGIcnfU5L3ldpn1XcxrGkPHwqgRx17/I2XRfqlFKk2vGkHWINn1kdXvzJZeuO3is6I9KLPFm0g==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@shikijs/core": "4.4.3",
+				"@shikijs/engine-javascript": "4.4.3",
+				"@shikijs/engine-oniguruma": "4.4.3",
+				"@shikijs/langs": "4.4.3",
+				"@shikijs/themes": "4.4.3",
+				"@shikijs/types": "4.4.3",
+				"@shikijs/vscode-textmate": "^10.0.2",
+				"@types/hast": "^3.0.5"
+			},
+			"engines": {
+				"node": ">=20"
+			}
+		},
+		"node_modules/shiki-stream": {
+			"version": "0.1.4",
+			"resolved": "https://registry.npmmirror.com/shiki-stream/-/shiki-stream-0.1.4.tgz",
+			"integrity": "sha512-4pz6JGSDmVTTkPJ/ueixHkFAXY4ySCc+unvCaDZV7hqq/sdJZirRxgIXSuNSKgiFlGTgRR97sdu2R8K55sPsrw==",
+			"license": "MIT",
+			"dependencies": {
+				"@shikijs/core": "^3.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/antfu"
+			},
+			"peerDependencies": {
+				"react": "^19.0.0",
+				"solid-js": "^1.9.0",
+				"vue": "^3.2.0"
+			},
+			"peerDependenciesMeta": {
+				"react": {
+					"optional": true
+				},
+				"solid-js": {
+					"optional": true
+				},
+				"vue": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/shiki-stream/node_modules/@shikijs/core": {
+			"version": "3.23.0",
+			"resolved": "https://registry.npmmirror.com/@shikijs/core/-/core-3.23.0.tgz",
+			"integrity": "sha512-NSWQz0riNb67xthdm5br6lAkvpDJRTgB36fxlo37ZzM2yq0PQFFzbd8psqC2XMPgCzo1fW6cVi18+ArJ44wqgA==",
+			"license": "MIT",
+			"dependencies": {
+				"@shikijs/types": "3.23.0",
+				"@shikijs/vscode-textmate": "^10.0.2",
+				"@types/hast": "^3.0.4",
+				"hast-util-to-html": "^9.0.5"
+			}
+		},
+		"node_modules/shiki-stream/node_modules/@shikijs/types": {
+			"version": "3.23.0",
+			"resolved": "https://registry.npmmirror.com/@shikijs/types/-/types-3.23.0.tgz",
+			"integrity": "sha512-3JZ5HXOZfYjsYSk0yPwBrkupyYSLpAE26Qc0HLghhZNGTZg/SKxXIIgoxOpmmeQP0RRSDJTk1/vPfw9tbw+jSQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@shikijs/vscode-textmate": "^10.0.2",
+				"@types/hast": "^3.0.4"
+			}
+		},
 		"node_modules/siginfo": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmmirror.com/siginfo/-/siginfo-2.0.0.tgz",
@@ -9126,6 +9679,16 @@
 				"source-map": "^0.6.0"
 			}
 		},
+		"node_modules/space-separated-tokens": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmmirror.com/space-separated-tokens/-/space-separated-tokens-2.0.2.tgz",
+			"integrity": "sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==",
+			"license": "MIT",
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/wooorm"
+			}
+		},
 		"node_modules/sprintf-js": {
 			"version": "1.1.3",
 			"resolved": "https://registry.npmmirror.com/sprintf-js/-/sprintf-js-1.1.3.tgz",
@@ -9158,6 +9721,18 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/stream-markdown": {
+			"version": "0.0.16",
+			"resolved": "https://registry.npmmirror.com/stream-markdown/-/stream-markdown-0.0.16.tgz",
+			"integrity": "sha512-2WoOxlpc3N5RLc3zGuW+g/w76z6ketWBY0N1YzDYbXds1qw7zrUBv5PTQ3DOtpqgCjLuF3P2iCfjJTEqWGv0NQ==",
+			"license": "MIT",
+			"dependencies": {
+				"shiki-stream": "0.1.4"
+			},
+			"peerDependencies": {
+				"shiki": ">=3.23.0"
+			}
+		},
 		"node_modules/stream-markdown-parser": {
 			"version": "1.1.4",
 			"resolved": "https://registry.npmmirror.com/stream-markdown-parser/-/stream-markdown-parser-1.1.4.tgz",
@@ -9172,6 +9747,103 @@
 				"markdown-it-sup": "^2.0.0",
 				"markdown-it-task-checkbox": "^1.0.6",
 				"markdown-it-ts": "^1.0.4"
+			}
+		},
+		"node_modules/stream-monaco": {
+			"version": "0.0.49",
+			"resolved": "https://registry.npmmirror.com/stream-monaco/-/stream-monaco-0.0.49.tgz",
+			"integrity": "sha512-ksZYJXw45NralnpgWqcptqrgDdbGZaTyYmvATvhlK8eY0tyeTxs0iuQzMTF4cpGf5OlIgkNJOfbFh4M97OozSw==",
+			"license": "MIT",
+			"dependencies": {
+				"@shikijs/monaco": "^3.23.0",
+				"alien-signals": "^2.0.8",
+				"shiki": "^3.23.0"
+			},
+			"bin": {
+				"run": "cli.mjs"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/Simon-He95"
+			},
+			"peerDependencies": {
+				"monaco-editor": ">=0.52.2 <0.56.0"
+			}
+		},
+		"node_modules/stream-monaco/node_modules/@shikijs/core": {
+			"version": "3.23.0",
+			"resolved": "https://registry.npmmirror.com/@shikijs/core/-/core-3.23.0.tgz",
+			"integrity": "sha512-NSWQz0riNb67xthdm5br6lAkvpDJRTgB36fxlo37ZzM2yq0PQFFzbd8psqC2XMPgCzo1fW6cVi18+ArJ44wqgA==",
+			"license": "MIT",
+			"dependencies": {
+				"@shikijs/types": "3.23.0",
+				"@shikijs/vscode-textmate": "^10.0.2",
+				"@types/hast": "^3.0.4",
+				"hast-util-to-html": "^9.0.5"
+			}
+		},
+		"node_modules/stream-monaco/node_modules/@shikijs/engine-javascript": {
+			"version": "3.23.0",
+			"resolved": "https://registry.npmmirror.com/@shikijs/engine-javascript/-/engine-javascript-3.23.0.tgz",
+			"integrity": "sha512-aHt9eiGFobmWR5uqJUViySI1bHMqrAgamWE1TYSUoftkAeCCAiGawPMwM+VCadylQtF4V3VNOZ5LmfItH5f3yA==",
+			"license": "MIT",
+			"dependencies": {
+				"@shikijs/types": "3.23.0",
+				"@shikijs/vscode-textmate": "^10.0.2",
+				"oniguruma-to-es": "^4.3.4"
+			}
+		},
+		"node_modules/stream-monaco/node_modules/@shikijs/engine-oniguruma": {
+			"version": "3.23.0",
+			"resolved": "https://registry.npmmirror.com/@shikijs/engine-oniguruma/-/engine-oniguruma-3.23.0.tgz",
+			"integrity": "sha512-1nWINwKXxKKLqPibT5f4pAFLej9oZzQTsby8942OTlsJzOBZ0MWKiwzMsd+jhzu8YPCHAswGnnN1YtQfirL35g==",
+			"license": "MIT",
+			"dependencies": {
+				"@shikijs/types": "3.23.0",
+				"@shikijs/vscode-textmate": "^10.0.2"
+			}
+		},
+		"node_modules/stream-monaco/node_modules/@shikijs/langs": {
+			"version": "3.23.0",
+			"resolved": "https://registry.npmmirror.com/@shikijs/langs/-/langs-3.23.0.tgz",
+			"integrity": "sha512-2Ep4W3Re5aB1/62RSYQInK9mM3HsLeB91cHqznAJMuylqjzNVAVCMnNWRHFtcNHXsoNRayP9z1qj4Sq3nMqYXg==",
+			"license": "MIT",
+			"dependencies": {
+				"@shikijs/types": "3.23.0"
+			}
+		},
+		"node_modules/stream-monaco/node_modules/@shikijs/themes": {
+			"version": "3.23.0",
+			"resolved": "https://registry.npmmirror.com/@shikijs/themes/-/themes-3.23.0.tgz",
+			"integrity": "sha512-5qySYa1ZgAT18HR/ypENL9cUSGOeI2x+4IvYJu4JgVJdizn6kG4ia5Q1jDEOi7gTbN4RbuYtmHh0W3eccOrjMA==",
+			"license": "MIT",
+			"dependencies": {
+				"@shikijs/types": "3.23.0"
+			}
+		},
+		"node_modules/stream-monaco/node_modules/@shikijs/types": {
+			"version": "3.23.0",
+			"resolved": "https://registry.npmmirror.com/@shikijs/types/-/types-3.23.0.tgz",
+			"integrity": "sha512-3JZ5HXOZfYjsYSk0yPwBrkupyYSLpAE26Qc0HLghhZNGTZg/SKxXIIgoxOpmmeQP0RRSDJTk1/vPfw9tbw+jSQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@shikijs/vscode-textmate": "^10.0.2",
+				"@types/hast": "^3.0.4"
+			}
+		},
+		"node_modules/stream-monaco/node_modules/shiki": {
+			"version": "3.23.0",
+			"resolved": "https://registry.npmmirror.com/shiki/-/shiki-3.23.0.tgz",
+			"integrity": "sha512-55Dj73uq9ZXL5zyeRPzHQsK7Nbyt6Y10k5s7OjuFZGMhpp4r/rsLBH0o/0fstIzX1Lep9VxefWljK/SKCzygIA==",
+			"license": "MIT",
+			"dependencies": {
+				"@shikijs/core": "3.23.0",
+				"@shikijs/engine-javascript": "3.23.0",
+				"@shikijs/engine-oniguruma": "3.23.0",
+				"@shikijs/langs": "3.23.0",
+				"@shikijs/themes": "3.23.0",
+				"@shikijs/types": "3.23.0",
+				"@shikijs/vscode-textmate": "^10.0.2",
+				"@types/hast": "^3.0.4"
 			}
 		},
 		"node_modules/string_decoder": {
@@ -9197,6 +9869,20 @@
 			},
 			"engines": {
 				"node": ">=8"
+			}
+		},
+		"node_modules/stringify-entities": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmmirror.com/stringify-entities/-/stringify-entities-4.0.4.tgz",
+			"integrity": "sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==",
+			"license": "MIT",
+			"dependencies": {
+				"character-entities-html4": "^2.0.0",
+				"character-entities-legacy": "^3.0.0"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/wooorm"
 			}
 		},
 		"node_modules/strip-ansi": {
@@ -9448,6 +10134,16 @@
 				"tmp": "^0.2.0"
 			}
 		},
+		"node_modules/trim-lines": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmmirror.com/trim-lines/-/trim-lines-3.0.1.tgz",
+			"integrity": "sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==",
+			"license": "MIT",
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/wooorm"
+			}
+		},
 		"node_modules/truncate-utf8-bytes": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmmirror.com/truncate-utf8-bytes/-/truncate-utf8-bytes-1.0.2.tgz",
@@ -9526,6 +10222,74 @@
 			"resolved": "https://registry.npmmirror.com/undici-types/-/undici-types-7.18.2.tgz",
 			"integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
 			"license": "MIT"
+		},
+		"node_modules/unist-util-is": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmmirror.com/unist-util-is/-/unist-util-is-6.0.1.tgz",
+			"integrity": "sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/unist": "^3.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/unist-util-position": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmmirror.com/unist-util-position/-/unist-util-position-5.0.0.tgz",
+			"integrity": "sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/unist": "^3.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/unist-util-stringify-position": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmmirror.com/unist-util-stringify-position/-/unist-util-stringify-position-4.0.0.tgz",
+			"integrity": "sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/unist": "^3.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/unist-util-visit": {
+			"version": "5.1.0",
+			"resolved": "https://registry.npmmirror.com/unist-util-visit/-/unist-util-visit-5.1.0.tgz",
+			"integrity": "sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/unist": "^3.0.0",
+				"unist-util-is": "^6.0.0",
+				"unist-util-visit-parents": "^6.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/unist-util-visit-parents": {
+			"version": "6.0.2",
+			"resolved": "https://registry.npmmirror.com/unist-util-visit-parents/-/unist-util-visit-parents-6.0.2.tgz",
+			"integrity": "sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/unist": "^3.0.0",
+				"unist-util-is": "^6.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
 		},
 		"node_modules/universalify": {
 			"version": "2.0.1",
@@ -9609,6 +10373,34 @@
 			"integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/vfile": {
+			"version": "6.0.3",
+			"resolved": "https://registry.npmmirror.com/vfile/-/vfile-6.0.3.tgz",
+			"integrity": "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/unist": "^3.0.0",
+				"vfile-message": "^4.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/vfile-message": {
+			"version": "4.0.3",
+			"resolved": "https://registry.npmmirror.com/vfile-message/-/vfile-message-4.0.3.tgz",
+			"integrity": "sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/unist": "^3.0.0",
+				"unist-util-stringify-position": "^4.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
 		},
 		"node_modules/vite": {
 			"version": "7.3.6",
@@ -10483,6 +11275,16 @@
 				}
 			}
 		},
+		"node_modules/zwitch": {
+			"version": "2.0.4",
+			"resolved": "https://registry.npmmirror.com/zwitch/-/zwitch-2.0.4.tgz",
+			"integrity": "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==",
+			"license": "MIT",
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/wooorm"
+			}
+		},
 		"packages/backend": {
 			"name": "@percho/backend",
 			"version": "0.1.0",
@@ -10511,8 +11313,11 @@
 				"@percho/shared": "*",
 				"electron-updater": "^6.8.9",
 				"markstream-react": "^0.0.55",
+				"monaco-editor": "^0.55.1",
 				"react": "^19.2.8",
 				"react-dom": "^19.2.8",
+				"stream-markdown": "^0.0.16",
+				"stream-monaco": "^0.0.49",
 				"thinking-orbs": "^0.3.1",
 				"zustand": "^5.0.14"
 			},

--- a/packages/backend/src/pi-backend.ts
+++ b/packages/backend/src/pi-backend.ts
@@ -564,7 +564,9 @@ export class PiBackend {
 	 */
 	async forkSession(sessionId: string, ref: { entryId?: string; text?: string }): Promise<SessionMeta> {
 		const entry = this.requireSession(sessionId);
-		if (entry.session.isStreaming) throw new Error("Cannot fork while the agent is running");
+		if (entry.session.isStreaming || entry.session.isCompacting) {
+			throw new Error("Cannot fork while the agent is running or context is compacting");
+		}
 		const sourceManager = entry.session.sessionManager;
 		const targetId = resolveForkEntryId(sourceManager, ref);
 		const file = sourceManager.getSessionFile();
@@ -593,7 +595,9 @@ export class PiBackend {
 		ref: { entryId?: string; text?: string; timestamp?: number },
 	): Promise<{ text: string; images: ImageInput[] }> {
 		const entry = this.requireSession(sessionId);
-		if (entry.session.isStreaming) throw new Error("Cannot recall while the agent is running");
+		if (entry.session.isStreaming || entry.session.isCompacting) {
+			throw new Error("Cannot recall while the agent is running or context is compacting");
+		}
 		const sm = entry.session.sessionManager;
 		const targetId = resolveRecallEntryId(sm, ref);
 		const target = sm.getEntry(targetId) as Extract<SessionEntry, { type: "message" }>;

--- a/packages/backend/src/vision/proxy-extension.ts
+++ b/packages/backend/src/vision/proxy-extension.ts
@@ -68,8 +68,11 @@ export interface VisionProxyOptions {
  * 原生多模态模型直通零成本；识别失败降级为占位文本，对话不中断
  * （context 钩子契约：不得 throw，异常时原样放行）。
  *
- * 已知限制：compaction 的摘要请求不经 context 钩子（SDK 直接 convertToLlm），
- * 文本模型 + 含图历史触发压缩时仍可能报 provider 图像错误（现状已有，后续项）。
+ * 已知限制：compaction / branch summary 的摘要请求不经 context 钩子（SDK 在
+ * compaction 内部直接 convertToLlm）。但 SDK 0.84 随后会 serializeConversation
+ * 成纯文本 prompt（contentText 只保留 text block），image block 不会进入摘要
+ * 请求，因此文本模型 + 含图历史触发压缩时不会报 provider 图像错误；代价是
+ * 图片内容不参与摘要（仅文字部分被摘要）。
  */
 export function makeVisionProxyExtension(options: VisionProxyOptions): InlineExtension {
 	return {

--- a/packages/backend/test/compaction-image.test.ts
+++ b/packages/backend/test/compaction-image.test.ts
@@ -1,0 +1,133 @@
+import { compact, generateSummaryWithUsage } from "@earendil-works/pi-coding-agent";
+import { describe, expect, it } from "vitest";
+
+/**
+ * SDK 0.84 的 compaction 摘要请求不经过 Agent 的 context 钩子，
+ * 但 generateSummaryWithUsage/generateTurnPrefixSummary 在 convertToLlm 之后
+ * 还会 serializeConversation 成纯文本 prompt。这个测试把该行为钉住：
+ * 文本模型 + 含图历史触发压缩时，摘要请求里不能出现 image block。
+ */
+const IMAGE = {
+	type: "image" as const,
+	data: "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAFgwJ/lP3xWQAAAABJRU5ErkJggg==",
+	mimeType: "image/png",
+};
+
+const TEXT_MODEL = {
+	id: "text-only",
+	name: "text-only",
+	api: "openai-completions",
+	provider: "test",
+	baseUrl: "https://example.invalid/v1",
+	reasoning: false,
+	input: ["text"],
+	cost: {},
+	contextWindow: 128_000,
+	maxTokens: 8_192,
+};
+
+const USAGE = {
+	input: 10,
+	output: 2,
+	cacheRead: 0,
+	cacheWrite: 0,
+	totalTokens: 12,
+	cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+};
+
+type CapturedRequest = { messages: { role: string; content: unknown }[] };
+
+function makeStreamFn(calls: CapturedRequest[]) {
+	return async (_model: unknown, context: CapturedRequest) => {
+		calls.push(structuredClone(context));
+		return {
+			result: async () => ({
+				stopReason: "success",
+				content: [{ type: "text", text: "摘要" }],
+				usage: USAGE,
+			}),
+		};
+	};
+}
+
+function expectTextOnlyPrompt(request: CapturedRequest): void {
+	expect(JSON.stringify(request).includes('"type":"image"')).toBe(false);
+	for (const message of request.messages) {
+		const types = Array.isArray(message.content)
+			? message.content.map((block) => (block as { type?: unknown }).type)
+			: [typeof message.content];
+		expect(types).toEqual(["text"]);
+	}
+}
+
+describe("compaction summary request image handling", () => {
+	it("generateSummaryWithUsage 把含图历史序列化为纯文本请求", async () => {
+		const calls: CapturedRequest[] = [];
+		await generateSummaryWithUsage(
+			[
+				{
+					role: "user",
+					timestamp: 1,
+					content: [{ type: "text", text: "请看这张图" }, IMAGE],
+				},
+				{ role: "assistant", timestamp: 2, content: [{ type: "text", text: "看到了" }] },
+			],
+			// 只验证请求形状，不需要真实 Model/StreamFn 完整类型。
+			TEXT_MODEL as never,
+			16_384,
+			"test-key",
+			{},
+			new AbortController().signal,
+			undefined,
+			undefined,
+			"off",
+			makeStreamFn(calls) as never,
+			{},
+			{ enabled: false },
+			undefined,
+		);
+		expect(calls).toHaveLength(1);
+		expectTextOnlyPrompt(calls[0] as CapturedRequest);
+	});
+
+	it("split-turn compact 的历史摘要与 turn prefix 摘要都不带 image block", async () => {
+		const calls: CapturedRequest[] = [];
+		const streamFn = makeStreamFn(calls) as never;
+		await compact(
+			{
+				firstKeptEntryId: "entry-kept",
+				messagesToSummarize: [
+					{
+						role: "user",
+						timestamp: 1,
+						content: [{ type: "text", text: "历史图片" }, IMAGE],
+					},
+				],
+				turnPrefixMessages: [
+					{
+						role: "user",
+						timestamp: 2,
+						content: [{ type: "text", text: "本 turn 前缀图片" }, IMAGE],
+					},
+				],
+				isSplitTurn: true,
+				tokensBefore: 10_000,
+				previousSummary: undefined,
+				fileOps: { read: new Set(), written: new Set(), edited: new Set() },
+				settings: { reserveTokens: 16_384, keepRecentTokens: 20_000 },
+			},
+			TEXT_MODEL as never,
+			"test-key",
+			{},
+			undefined,
+			new AbortController().signal,
+			"off",
+			streamFn,
+			{},
+			{ enabled: false },
+			undefined,
+		);
+		expect(calls).toHaveLength(2);
+		for (const call of calls) expectTextOnlyPrompt(call);
+	});
+});

--- a/packages/backend/test/session-tree-operations.test.ts
+++ b/packages/backend/test/session-tree-operations.test.ts
@@ -1,0 +1,39 @@
+import type { AgentSession } from "@earendil-works/pi-coding-agent";
+import { describe, expect, it } from "vitest";
+import { PiBackend } from "../src/pi-backend";
+import type { SessionRegistry } from "../src/session/registry";
+
+interface SessionState {
+	isStreaming: boolean;
+	isCompacting: boolean;
+}
+
+/** Inject a minimal session so guard behavior stays isolated from the SDK and filesystem. */
+function makeBackend(state: SessionState): PiBackend {
+	const backend = new PiBackend({ projectTrust: false, permissionGates: false });
+	const registry = (backend as unknown as { registry: SessionRegistry }).registry;
+	registry.add({
+		session: { sessionId: "s1", ...state } as unknown as AgentSession,
+		unsubscribe: () => {},
+		cwd: "/tmp",
+	});
+	return backend;
+}
+
+describe("PiBackend session tree operation guards", () => {
+	it("rejects fork while context compaction is rewriting the source session", async () => {
+		const backend = makeBackend({ isStreaming: false, isCompacting: true });
+
+		await expect(backend.forkSession("s1", { entryId: "target" })).rejects.toThrow(
+			"Cannot fork while the agent is running or context is compacting",
+		);
+	});
+
+	it("rejects recall while context compaction is rewriting the source session", async () => {
+		const backend = makeBackend({ isStreaming: false, isCompacting: true });
+
+		await expect(backend.recallMessage("s1", { entryId: "target" })).rejects.toThrow(
+			"Cannot recall while the agent is running or context is compacting",
+		);
+	});
+});

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -16,6 +16,9 @@
 		"start": "electron-vite preview"
 	},
 	"dependencies": {
+		"@dnd-kit/core": "^6.3.1",
+		"@dnd-kit/modifiers": "^9.0.0",
+		"@dnd-kit/sortable": "^10.0.0",
 		"@earendil-works/pi-ai": "0.84.0",
 		"@earendil-works/pi-coding-agent": "0.84.0",
 		"@percho/backend": "*",

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -25,8 +25,11 @@
 		"@percho/shared": "*",
 		"electron-updater": "^6.8.9",
 		"markstream-react": "^0.0.55",
+		"monaco-editor": "^0.55.1",
 		"react": "^19.2.8",
 		"react-dom": "^19.2.8",
+		"stream-markdown": "^0.0.16",
+		"stream-monaco": "^0.0.49",
 		"thinking-orbs": "^0.3.1",
 		"zustand": "^5.0.14"
 	},

--- a/packages/desktop/src/main/ui-state.ts
+++ b/packages/desktop/src/main/ui-state.ts
@@ -25,6 +25,7 @@ function normalize(parsed: Partial<UiState>): UiState {
 		thinkingLevel: typeof parsed.thinkingLevel === "string" ? parsed.thinkingLevel : "medium",
 		theme,
 		background: { image: typeof background?.image === "string" ? background.image : null, dim },
+		sessionRailEnabled: typeof parsed.sessionRailEnabled === "boolean" ? parsed.sessionRailEnabled : false,
 	};
 }
 

--- a/packages/desktop/src/renderer/index.html
+++ b/packages/desktop/src/renderer/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta
       http-equiv="Content-Security-Policy"
-      content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: pi-bg:; font-src 'self' data:"
+      content="default-src 'self'; script-src 'self' 'wasm-unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: pi-bg:; font-src 'self' data:"
     />
     <title>Percho</title>
     <!-- 开屏动画（黑白哑光粒子光团 → 散场）：样式 splash.css（渲染阻塞，首帧前就绪）；

--- a/packages/desktop/src/renderer/src/App.tsx
+++ b/packages/desktop/src/renderer/src/App.tsx
@@ -6,6 +6,7 @@ import { MessageList } from "./components/chat/MessageList";
 import { TodoPanel } from "./components/chat/TodoPanel";
 import { ProjectPage } from "./components/projects/ProjectPage";
 import { ApprovalDock } from "./components/session/ApprovalDock";
+import { SessionRail } from "./components/session/SessionRail";
 import { SessionTabBar } from "./components/session/SessionTabBar";
 import { TrustDialog } from "./components/session/TrustDialog";
 import { SettingsDialog } from "./components/settings/SettingsDialog";
@@ -101,6 +102,7 @@ export default function App() {
 						<main className="relative min-h-0 flex-1">
 							{showEmpty ? <EmptyState /> : <MessageList />}
 							<TodoPanel />
+							<SessionRail />
 						</main>
 						<ApprovalDock sessionId={activeSessionId} hideComposer={showEmpty} />
 					</>

--- a/packages/desktop/src/renderer/src/components/chat/Markdown.tsx
+++ b/packages/desktop/src/renderer/src/components/chat/Markdown.tsx
@@ -15,6 +15,14 @@ const SMOOTH_OPTIONS: SmoothMarkdownStreamOptions = {
 	// 其余（targetLatencyMs 900 / catchUpLatencyMs 350 / catchUpThreshold 600 / max 1000cps）用默认
 };
 
+const CODE_BLOCK_PROPS = {
+	// 标题栏在视觉上被 CSS 悬浮化（见 globals.css），这里只裁掉多余按钮：字号三键/全屏/预览，
+	// 保留折叠 + 复制。不能用 showHeader:false——它会连按钮一起去掉，且折叠是组件内部 state，外部无法控制。
+	showFontSizeButtons: false,
+	showExpandButton: false,
+	showPreviewButton: false,
+} as const;
+
 /** 减速动效偏好：直接关闭 pacing（直出）；库 CSS 自带 animation:none 处理淡入 */
 const REDUCED_MOTION =
 	typeof window !== "undefined" && window.matchMedia("(prefers-reduced-motion: reduce)").matches;
@@ -30,7 +38,9 @@ const REDUCED_MOTION =
  *    controller 才能存活并平滑追平。
  * 2. fade：新块节点 enter 淡入（.28s）+ 文本节点新增内容交替淡入（text-node-stream-delta a/b）。
  * 样式：组件自带 CSS（:where() 零优先级），视觉覆写集中在 globals.css 的 .markdown-body 下。
- * isDark 驱动代码块 shiki 主题（vitesse-light/dark）与容器深浅。
+ * isDark 驱动代码块 shiki 主题（vitesse-light/dark）与容器深浅。注意必须显式传
+ * codeBlockLightTheme/codeBlockDarkTheme：不传时 stream-monaco 回退到 themes[0]（默认 vitesse-dark），
+ * 浅色模式下代码块也会是深色。
  */
 export function Markdown({ text, streaming }: { text: string; streaming?: boolean }) {
 	const isDark = useThemeStore((s) => s.resolved === "dark");
@@ -48,6 +58,9 @@ export function Markdown({ text, streaming }: { text: string; streaming?: boolea
 				smoothStreaming={smoothableRef.current}
 				smoothStreamingOptions={SMOOTH_OPTIONS}
 				isDark={isDark}
+				codeBlockLightTheme="vitesse-light"
+				codeBlockDarkTheme="vitesse-dark"
+				codeBlockProps={CODE_BLOCK_PROPS}
 				deferNodesUntilVisible={false}
 			/>
 		</div>

--- a/packages/desktop/src/renderer/src/components/chat/MessageItem.tsx
+++ b/packages/desktop/src/renderer/src/components/chat/MessageItem.tsx
@@ -70,16 +70,19 @@ function CopyButton({ text }: { text: string }) {
 	);
 }
 
-/** 分叉按钮：以该 assistant 消息为结尾生成新会话并切换；agent 运行中/分叉中禁用 */
+/** 分叉按钮：以该 assistant 消息为结尾生成新会话并切换；agent 运行、压缩或分叉中禁用 */
 function ForkButton({ entryId, text }: { entryId?: string; text: string }) {
 	const t = useT();
 	const activeSessionId = useSessionsStore((s) => s.activeSessionId);
-	const agentActive = useTranscriptStore((s) => selectTranscript(s, activeSessionId).agentActive);
+	const sessionBusy = useTranscriptStore((s) => {
+		const transcript = selectTranscript(s, activeSessionId);
+		return transcript.agentActive || transcript.compacting;
+	});
 	const forkSession = useSessionsStore((s) => s.forkSession);
 	const [forking, setForking] = useState(false);
 
 	const handleFork = () => {
-		if (forking || agentActive) return;
+		if (forking || sessionBusy) return;
 		setForking(true);
 		// entryId 精确定位（历史消息）；流式刚提交的消息无 entryId，按正文文本兜底匹配
 		void forkSession(entryId ? { entryId } : { text }).finally(() => setForking(false));
@@ -89,7 +92,7 @@ function ForkButton({ entryId, text }: { entryId?: string; text: string }) {
 		<button
 			type="button"
 			onClick={handleFork}
-			disabled={agentActive || forking}
+			disabled={sessionBusy || forking}
 			aria-label={t("message.fork")}
 			className="flex h-6 w-6 items-center justify-center rounded-md text-ink-faint transition-colors duration-150 hover:bg-border/70 hover:text-ink-2 disabled:cursor-not-allowed"
 		>
@@ -98,16 +101,19 @@ function ForkButton({ entryId, text }: { entryId?: string; text: string }) {
 	);
 }
 
-/** 撤回按钮：会话回退到该用户消息之前，内容放回输入框继续编辑；agent 运行中禁用 */
+/** 撤回按钮：会话回退到该用户消息之前，内容放回输入框继续编辑；agent 运行或压缩中禁用 */
 function RecallButton({ entryId, text, timestamp }: { entryId?: string; text: string; timestamp: number }) {
 	const t = useT();
 	const activeSessionId = useSessionsStore((s) => s.activeSessionId);
-	const agentActive = useTranscriptStore((s) => selectTranscript(s, activeSessionId).agentActive);
+	const sessionBusy = useTranscriptStore((s) => {
+		const transcript = selectTranscript(s, activeSessionId);
+		return transcript.agentActive || transcript.compacting;
+	});
 	const recallMessage = useSessionsStore((s) => s.recallMessage);
 	const [recalling, setRecalling] = useState(false);
 
 	const handleRecall = () => {
-		if (recalling || agentActive) return;
+		if (recalling || sessionBusy) return;
 		setRecalling(true);
 		// entryId 精确定位（历史消息）；实时消息无 entryId，按文本+时间戳兑底匹配
 		void recallMessage({ entryId, text: text || undefined, timestamp }).finally(() => setRecalling(false));
@@ -117,7 +123,7 @@ function RecallButton({ entryId, text, timestamp }: { entryId?: string; text: st
 		<button
 			type="button"
 			onClick={handleRecall}
-			disabled={agentActive || recalling}
+			disabled={sessionBusy || recalling}
 			aria-label={t("message.recall")}
 			className="flex h-6 w-6 items-center justify-center rounded-md text-ink-faint transition-colors duration-150 hover:bg-border/70 hover:text-ink-2 disabled:cursor-not-allowed"
 		>

--- a/packages/desktop/src/renderer/src/components/session/SessionRail.tsx
+++ b/packages/desktop/src/renderer/src/components/session/SessionRail.tsx
@@ -1,0 +1,155 @@
+import type { SessionMeta } from "@percho/shared";
+import { useState } from "react";
+import { useT } from "../../i18n";
+import { useSessionsStore } from "../../stores/sessions";
+import { useUiStore } from "../../stores/ui";
+import { useUiPreferencesStore } from "../../stores/ui-preferences";
+import { CloseIcon } from "../icons";
+import {
+	type SessionStatus,
+	sessionLetter,
+	sessionProjectDir,
+	sessionTitle,
+	useSessionStatus,
+} from "./session-status";
+
+/**
+ * 左侧会话轨道（可选交互，设置 → 外观 开关）：聊天页左侧垂直居中一列短线。
+ * 悬停/聚焦时短线原地「膨胀」成悬浮胶囊（项目图标 + 会话标题，bg-surface + shadow-pop 全圆角 pill），
+ * 相邻 ±1 变成一半大的胶囊（同样白底圆角，内容可见被裁断）、±2 变成迷你空胶囊，
+ * 连续划过即 dock 式波浪（距离类 is-expanded/is-near-1/is-near-2 由 JS 按 expandedId 下标算出，
+ * 比纯 CSS :has 链更易控——呼吸/内容显隐都要按距离精确开关）。
+ * **行高同步分级撑开**（16 → 40/32/20px = 胶囊 + 留白，同时长同曲线）：按钮在文档流内，
+ * 行一撑上下邻居自然让位，胶囊各行其道互不叠压；垂直居中列以悬停项为中心对称「分开」。
+ * 只做「看 + 切换」——展开胶囊末尾有关闭 ×（仅展开态可见，同顶栏 group-hover 语义）；
+ * 新建/排序仍走顶栏；关闭后顶栏/轨道同读 sessions 数组，天然双向同步。
+ * 收起态是纯覆盖层（pointer-events-none），
+ * 不挤压聊天布局；胶囊 absolute 于按钮垂直居中，随行高动但不参与布局。
+ */
+export function SessionRail() {
+	const enabled = useUiPreferencesStore((s) => s.sessionRailEnabled);
+	const view = useUiStore((s) => s.view);
+	const sessions = useSessionsStore((s) => s.sessions);
+	if (!enabled || view !== "chat" || sessions.length === 0) return null;
+	return <SessionRailInner sessions={sessions} />;
+}
+
+function SessionRailInner({ sessions }: { sessions: SessionMeta[] }) {
+	const t = useT();
+	const activeSessionId = useSessionsStore((s) => s.activeSessionId);
+	const switchSession = useSessionsStore((s) => s.switchSession);
+	const setView = useUiStore((s) => s.setView);
+	const [expandedId, setExpandedId] = useState<string | null>(null);
+	const expandedIndex = sessions.findIndex((s) => s.sessionId === expandedId);
+
+	return (
+		<nav
+			className="pointer-events-none absolute inset-y-0 left-0 z-30"
+			aria-label={t("settings.sessionRail")}
+		>
+			{/* 容器只占视口外沿 288px 且不接指针：短线按钮列（w-8）单独可点可滚；胶囊向右浮出被 x 裁剪在容器内 */}
+			<div className="h-full w-[288px] overflow-y-auto overflow-x-hidden [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
+				{/* min-h-full + justify-center：不足一屏时垂直居中，超出时自然撑开从顶部滚动（justify-content:safe center 的经典替代）；无 gap、行高 16px 的紧凑间距 */}
+				<div className="flex min-h-full flex-col justify-center py-6">
+					{sessions.map((session, index) => (
+						<RailItem
+							key={session.sessionId}
+							session={session}
+							isActive={session.sessionId === activeSessionId}
+							distance={expandedIndex === -1 ? null : Math.abs(index - expandedIndex)}
+							onExpand={() => setExpandedId(session.sessionId)}
+							onCollapse={() => setExpandedId((prev) => (prev === session.sessionId ? null : prev))}
+							onSelect={() => {
+								switchSession(session.sessionId);
+								setView("chat");
+							}}
+						/>
+					))}
+				</div>
+			</div>
+		</nav>
+	);
+}
+
+/** 单条短线：胶囊与短线是同一个元素（rail-capsule），收起 = 3px 状态线（子元素透明裁剪），
+ *  展开 = 悬浮胶囊（图标 + 标题淡入）。键盘可达：聚焦即展开（展开本身即焦点指示），
+ *  Enter/Space 走原生 click 切换 */
+function RailItem({
+	session,
+	isActive,
+	distance,
+	onExpand,
+	onCollapse,
+	onSelect,
+}: {
+	session: SessionMeta;
+	isActive: boolean;
+	/** 与展开项的行距：0 = 自身展开，1/2 = 波浪跟涨档位，null = 无展开项 */
+	distance: number | null;
+	onExpand: () => void;
+	onCollapse: () => void;
+	onSelect: () => void;
+}) {
+	const t = useT();
+	const status = useSessionStatus(session.sessionId);
+	const closeSession = useSessionsStore((s) => s.closeSession);
+	const title = sessionTitle(session, t("tabbar.untitled"));
+	const dir = sessionProjectDir(session);
+	const stateClass =
+		distance === 0 ? "is-expanded" : distance === 1 ? "is-near-1" : distance === 2 ? "is-near-2" : "";
+	return (
+		<button
+			type="button"
+			className={`session-rail-item pointer-events-auto relative h-4 w-8 shrink-0 outline-none ${stateClass}`}
+			onMouseEnter={onExpand}
+			onMouseLeave={onCollapse}
+			onFocus={onExpand}
+			onBlur={onCollapse}
+			onClick={onSelect}
+			aria-label={dir && dir !== title ? `${title}（${dir}）` : title}
+			aria-pressed={isActive}
+		>
+			<span className={`rail-capsule h-[2px] ${railLineClass(status, isActive)}`} aria-hidden="true">
+				<span className="flex min-w-0 flex-1 items-center gap-2 px-2.5">
+					<span
+						className={`relative flex h-4 w-4 shrink-0 items-center justify-center rounded text-[10px] font-semibold text-on-ink ${railAvatarClass(status, isActive)}`}
+					>
+						{sessionLetter(session).toUpperCase()}
+						{status === "done" && (
+							<span className="absolute -right-0.5 -top-0.5 h-1.5 w-1.5 rounded-full bg-green-500 ring-1 ring-surface" />
+						)}
+					</span>
+					<span className="min-w-0 flex-1 truncate text-left text-sm text-ink">{title}</span>
+					{/* 关闭 ×：仅展开态可见可点（CSS rail-close 控 opacity + pointer-events）；
+					    span 而非 button（外层已是 button），stopPropagation 防触发切换；交互对齐顶栏 TabPill */}
+					<span
+						className="rail-close flex h-4 shrink-0 items-center justify-center overflow-hidden rounded text-ink-dim hover:text-ink"
+						aria-hidden="true"
+						onClick={(e) => {
+							e.stopPropagation();
+							void closeSession(session.sessionId);
+						}}
+					>
+						<CloseIcon />
+					</span>
+				</span>
+			</span>
+		</button>
+	);
+}
+
+/** 收起态细线（优先级同顶栏）：审批 = 琥珀 / 工作中 = 墨色呼吸 / 完成未读 = 绿 / 当前会话 = 更长更深的墨色。
+ *  直角 2px 细线（codex 风），三档宽度：空闲 12 / 状态 16 / 当前 20 */
+function railLineClass(status: SessionStatus, isActive: boolean): string {
+	if (status === "attention") return "w-4 bg-amber-500";
+	if (status === "working") return "w-4 bg-ink rail-working";
+	if (status === "done") return "w-4 bg-green-500";
+	return isActive ? "w-5 bg-ink" : "w-3 bg-ink-faint";
+}
+
+/** 展开态胶囊头像（与 TabPill 完全同语义）：审批琥珀 / 工作中墨色呼吸 / 完成未读绿点角标 / 当前更深 */
+function railAvatarClass(status: SessionStatus, isActive: boolean): string {
+	if (status === "attention") return "bg-amber-500";
+	if (status === "working") return "bg-ink tab-avatar-working";
+	return isActive ? "bg-ink" : "bg-ink-faint";
+}

--- a/packages/desktop/src/renderer/src/components/session/SessionTabBar.tsx
+++ b/packages/desktop/src/renderer/src/components/session/SessionTabBar.tsx
@@ -1,5 +1,23 @@
+import type { DragEndEvent, Modifier } from "@dnd-kit/core";
+import {
+	closestCenter,
+	DndContext,
+	DragOverlay,
+	KeyboardSensor,
+	PointerSensor,
+	useSensor,
+	useSensors,
+} from "@dnd-kit/core";
+import { restrictToHorizontalAxis, restrictToParentElement } from "@dnd-kit/modifiers";
+import {
+	horizontalListSortingStrategy,
+	SortableContext,
+	sortableKeyboardCoordinates,
+	useSortable,
+} from "@dnd-kit/sortable";
 import type { SessionMeta } from "@percho/shared";
-import { useEffect, useRef } from "react";
+import type { ComponentProps } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useT } from "../../i18n";
 import { useSessionsStore } from "../../stores/sessions";
 import { useTranscriptStore } from "../../stores/transcript";
@@ -10,12 +28,45 @@ import { UpdateButton } from "./UpdateButton";
 /** tab 状态（优先级递减）：等待权限 > 工作中 > 完成未读 > 空闲 */
 type TabStatus = "attention" | "working" | "done" | "idle";
 
-/** 单个会话 tab：独立订阅自己的运行状态（切走后状态不丢） */
-function SessionTab({ session, isActive }: { session: SessionMeta; isActive: boolean }) {
+/** 拖拽让位/落位的减速曲线（浏览器标签同款手感） */
+const SORT_EASE = "cubic-bezier(0.2, 0, 0, 1)";
+
+/** 拖拽轴锁定（挂在 DragOverlay 上）：只许水平移动，且钳在 tab 条容器内（浏览器标签行为）。
+ *  必须挂 overlay：ghost 是 fixed 定位不参与滚动区域；若让指针 transform 落在流内胶囊上，
+ *  Chromium 会把 transform 后的盒子计入滚动容器的可滚动区域 → 拖到右缘 scrollWidth 持续增长，
+ *  auto-scroll 追着新边缘滚 = 无限右滚（左侧有 scrollLeft>=0 天然边界所以没事） */
+const DRAG_MODIFIERS: Modifier[] = [restrictToHorizontalAxis, restrictToParentElement];
+
+/** ghost 落位动画：fade 回到槽位（duration 用自己的曲线节奏） */
+const DROP_ANIMATION = { duration: 180, easing: SORT_EASE };
+
+const prefersReducedMotion = (): boolean => window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+
+/** 拖拽中的全局 cursor（指针常在胶囊外的间隙上，须挂在根元素） */
+function setDraggingCursor(on: boolean): void {
+	document.documentElement.classList.toggle("tab-dragging-cursor", on);
+}
+
+/** 胶囊视觉（presentational）：真实胶囊与拖拽 ghost 共用一份渲染。
+ *  独立订阅自己的运行状态（切走后状态不丢）；苹果式设计：状态全收拢到头像图标
+ *  （黑白色系，仅语义色保留琥珀/绿点），胶囊本体与标题完全不动 */
+function TabPill({
+	session,
+	isActive,
+	ghost = false,
+	hidden = false,
+	buttonProps,
+}: {
+	session: SessionMeta;
+	isActive: boolean;
+	/** DragOverlay ghost：拾起视觉，无交互 */
+	ghost?: boolean;
+	/** 真实胶囊正被 ghost 接管：隐藏本体但保留布局槽位（邻居让位计算依赖它） */
+	hidden?: boolean;
+	buttonProps?: ComponentProps<"button">;
+}) {
 	const t = useT();
-	const switchSession = useSessionsStore((s) => s.switchSession);
 	const closeSession = useSessionsStore((s) => s.closeSession);
-	const setView = useUiStore((s) => s.setView);
 	// selector 返回字符串原始值，引用稳定不触发多余渲染
 	const status = useTranscriptStore((s): TabStatus => {
 		const entry = s.bySession[session.sessionId];
@@ -27,7 +78,6 @@ function SessionTab({ session, isActive }: { session: SessionMeta; isActive: boo
 	});
 	// 图标字母 = 项目名（cwd 最后一段）首字母，与会话标题无关
 	const letter = session.cwd.split("/").filter(Boolean).pop()?.[0] ?? "P";
-	// 苹果式设计：状态全部收拢到头像图标（黑白色系，仅语义色保留琥珀/绿点），胶囊本体与标题完全不动
 	const avatarClass =
 		status === "attention"
 			? "bg-amber-500"
@@ -39,13 +89,12 @@ function SessionTab({ session, isActive }: { session: SessionMeta; isActive: boo
 	return (
 		<button
 			type="button"
-			className={`no-drag group relative flex w-52 shrink-0 cursor-pointer items-center gap-2 rounded-lg px-2.5 py-1.5 text-sm transition-colors ${
+			{...buttonProps}
+			style={{ touchAction: "none", ...(hidden ? { opacity: 0 } : null) }}
+			className={`no-drag tab-pill group relative flex w-52 cursor-pointer items-center gap-2 rounded-lg px-2.5 py-1.5 text-sm ${
 				isActive ? "bg-border/80 text-ink" : "text-ink-dim hover:bg-hover hover:text-ink"
-			}`}
-			onClick={() => {
-				switchSession(session.sessionId);
-				setView("chat");
-			}}
+			} ${ghost ? "tab-dragging" : ""}`}
+			onClick={ghost ? undefined : buttonProps?.onClick}
 		>
 			<span
 				className={`relative flex h-4 w-4 shrink-0 items-center justify-center rounded text-[10px] font-semibold text-on-ink ${avatarClass}`}
@@ -59,31 +108,84 @@ function SessionTab({ session, isActive }: { session: SessionMeta; isActive: boo
 				<span className="block truncate pr-6 text-left">
 					{session.name ?? session.cwd.split("/").filter(Boolean).pop() ?? t("tabbar.untitled")}
 				</span>
-				<span
-					className="invisible absolute right-0 top-1/2 -translate-y-1/2 p-1 text-ink-dim opacity-0 transition-opacity hover:text-ink group-hover:visible group-hover:opacity-100"
-					aria-hidden="true"
-					onClick={(e) => {
-						e.stopPropagation();
-						void closeSession(session.sessionId);
-					}}
-				>
-					<CloseIcon />
-				</span>
+				{!ghost && (
+					<span
+						className="invisible absolute right-0 top-1/2 -translate-y-1/2 p-1 text-ink-dim opacity-0 transition-opacity hover:text-ink group-hover:visible group-hover:opacity-100"
+						aria-hidden="true"
+						onClick={(e) => {
+							e.stopPropagation();
+							void closeSession(session.sessionId);
+						}}
+					>
+						<CloseIcon />
+					</span>
+				)}
 			</span>
 		</button>
 	);
 }
 
-/** 顶栏：macOS hiddenInset 红绿灯左侧，会话 tab 从右排开 */
+/** 单个会话 tab：几何层（useSortable 的 transform/transition）在 wrapper div 上按 dnd-kit 协议
+ *  原样应用——transition 含 "none" 帧时绝不能覆盖成动画，那是 FLIP 布点帧（覆盖会造成落位回闪）；
+ *  拖拽本体隐藏、由 DragOverlay 的 ghost 跟随指针（见 DRAG_MODIFIERS 注释） */
+function SessionTab({ session, isActive }: { session: SessionMeta; isActive: boolean }) {
+	const switchSession = useSessionsStore((s) => s.switchSession);
+	const setView = useUiStore((s) => s.setView);
+	const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
+		id: session.sessionId,
+		// 自定义让位/落位节奏；reduced-motion 传 null = dnd-kit 不再给出过渡串
+		transition: prefersReducedMotion() ? null : { duration: 220, easing: SORT_EASE },
+	});
+	return (
+		<div
+			ref={setNodeRef}
+			className="shrink-0"
+			style={{
+				transform: transform ? `translate3d(${transform.x}px, ${transform.y}px, 0)` : undefined,
+				transition: transition || undefined,
+			}}
+		>
+			<TabPill
+				session={session}
+				isActive={isActive}
+				hidden={isDragging}
+				buttonProps={{
+					...attributes,
+					...listeners,
+					onClick: () => {
+						switchSession(session.sessionId);
+						setView("chat");
+					},
+				}}
+			/>
+		</div>
+	);
+}
+
+/** 顶栏：macOS hiddenInset 红绿灯左侧，会话 tab 从右排开，可拖拽排序（浏览器标签式） */
 export function SessionTabBar() {
 	const t = useT();
 	const sessions = useSessionsStore((s) => s.sessions);
 	const activeSessionId = useSessionsStore((s) => s.activeSessionId);
 	const createDraftSession = useSessionsStore((s) => s.createDraftSession);
+	const reorderSessions = useSessionsStore((s) => s.reorderSessions);
 	const cwd = useSessionsStore((s) => s.cwd);
 	const view = useUiStore((s) => s.view);
 	const setView = useUiStore((s) => s.setView);
 	const scrollerRef = useRef<HTMLDivElement>(null);
+	const [activeId, setActiveId] = useState<string | null>(null);
+	const activeSession = sessions.find((s) => s.sessionId === activeId);
+	// 拖拽期间：顶栏整体退出窗口拖拽区（胶囊间隙本是 drag-region，指针扫过会被 macOS 当拖窗口吞事件）
+	const dragging = activeId !== null;
+	// 5px 激活距离：原地点击/关胶囊不触发拖拽；键盘传感器支持 Space 抬起 + 左右键移动
+	const sensors = useSensors(
+		useSensor(PointerSensor, { activationConstraint: { distance: 5 } }),
+		useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates }),
+	);
+	const endDrag = () => {
+		setActiveId(null);
+		setDraggingCursor(false);
+	};
 
 	// 正在查看的会话：完成未读标记立即清除（覆盖切 tab 与 projects ↔ chat 视图切换）
 	useEffect(() => {
@@ -109,7 +211,9 @@ export function SessionTabBar() {
 	}, []);
 
 	return (
-		<div className="drag-region flex h-12 shrink-0 items-center gap-1 border-b border-border bg-canvas pl-20 pr-3">
+		<div
+			className={`${dragging ? "" : "drag-region"} flex h-12 shrink-0 items-center gap-1 border-b border-border bg-canvas pl-20 pr-3`}
+		>
 			<button
 				type="button"
 				className={`no-drag shrink-0 rounded-lg p-1.5 transition-colors ${
@@ -124,13 +228,41 @@ export function SessionTabBar() {
 				ref={scrollerRef}
 				className="flex min-w-0 flex-1 items-center gap-1 overflow-x-scroll [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
 			>
-				{sessions.map((session) => (
-					<SessionTab
-						key={session.sessionId}
-						session={session}
-						isActive={session.sessionId === activeSessionId}
-					/>
-				))}
+				<DndContext
+					sensors={sensors}
+					collisionDetection={closestCenter}
+					onDragStart={({ active }) => {
+						setActiveId(String(active.id));
+						setDraggingCursor(true);
+					}}
+					onDragEnd={({ active, over }: DragEndEvent) => {
+						endDrag();
+						if (over && active.id !== over.id) {
+							reorderSessions(String(active.id), String(over.id));
+						}
+					}}
+					onDragCancel={endDrag}
+				>
+					<SortableContext items={sessions.map((s) => s.sessionId)} strategy={horizontalListSortingStrategy}>
+						{sessions.map((session) => (
+							<SessionTab
+								key={session.sessionId}
+								session={session}
+								isActive={session.sessionId === activeSessionId}
+							/>
+						))}
+					</SortableContext>
+					{/* 拖拽 ghost：fixed 定位（不参与滚动区域 → 不会撑大 scrollWidth），
+					    落位时 fade 回槽位，真实胶囊同时 fade in（.tab-pill 的 opacity 过渡） */}
+					<DragOverlay
+						modifiers={DRAG_MODIFIERS}
+						dropAnimation={prefersReducedMotion() ? null : DROP_ANIMATION}
+					>
+						{activeSession ? (
+							<TabPill session={activeSession} isActive={activeSession.sessionId === activeSessionId} ghost />
+						) : null}
+					</DragOverlay>
+				</DndContext>
 			</div>
 			<UpdateButton />
 			{view !== "projects" && (

--- a/packages/desktop/src/renderer/src/components/session/SessionTabBar.tsx
+++ b/packages/desktop/src/renderer/src/components/session/SessionTabBar.tsx
@@ -23,10 +23,8 @@ import { useSessionsStore } from "../../stores/sessions";
 import { useTranscriptStore } from "../../stores/transcript";
 import { useUiStore } from "../../stores/ui";
 import { CloseIcon, ComposeIcon, GridIcon } from "../icons";
+import { sessionLetter, sessionTitle, useSessionStatus } from "./session-status";
 import { UpdateButton } from "./UpdateButton";
-
-/** tab 状态（优先级递减）：等待权限 > 工作中 > 完成未读 > 空闲 */
-type TabStatus = "attention" | "working" | "done" | "idle";
 
 /** 拖拽让位/落位的减速曲线（浏览器标签同款手感） */
 const SORT_EASE = "cubic-bezier(0.2, 0, 0, 1)";
@@ -67,17 +65,10 @@ function TabPill({
 }) {
 	const t = useT();
 	const closeSession = useSessionsStore((s) => s.closeSession);
-	// selector 返回字符串原始值，引用稳定不触发多余渲染
-	const status = useTranscriptStore((s): TabStatus => {
-		const entry = s.bySession[session.sessionId];
-		if (!entry) return "idle";
-		if (entry.pendingPermissions.length > 0) return "attention";
-		if (entry.agentActive) return "working";
-		if (entry.unseenCompletion) return "done";
-		return "idle";
-	});
+	// 状态订阅与左侧会话轨道共用（优先级：审批 > 工作中 > 完成未读 > 空闲）
+	const status = useSessionStatus(session.sessionId);
 	// 图标字母 = 项目名（cwd 最后一段）首字母，与会话标题无关
-	const letter = session.cwd.split("/").filter(Boolean).pop()?.[0] ?? "P";
+	const letter = sessionLetter(session);
 	const avatarClass =
 		status === "attention"
 			? "bg-amber-500"
@@ -105,9 +96,7 @@ function TabPill({
 				)}
 			</span>
 			<span className="relative min-w-0 flex-1">
-				<span className="block truncate pr-6 text-left">
-					{session.name ?? session.cwd.split("/").filter(Boolean).pop() ?? t("tabbar.untitled")}
-				</span>
+				<span className="block truncate pr-6 text-left">{sessionTitle(session, t("tabbar.untitled"))}</span>
 				{!ghost && (
 					<span
 						className="invisible absolute right-0 top-1/2 -translate-y-1/2 p-1 text-ink-dim opacity-0 transition-opacity hover:text-ink group-hover:visible group-hover:opacity-100"

--- a/packages/desktop/src/renderer/src/components/session/session-status.test.ts
+++ b/packages/desktop/src/renderer/src/components/session/session-status.test.ts
@@ -1,0 +1,35 @@
+import type { SessionMeta } from "@percho/shared";
+import { describe, expect, it } from "vitest";
+import { sessionLetter, sessionProjectDir, sessionTitle } from "./session-status";
+
+function meta(overrides: Partial<SessionMeta>): SessionMeta {
+	return { sessionId: "s1", cwd: "/proj/demo", active: true, messageCount: 0, createdAt: 1, ...overrides };
+}
+
+describe("sessionTitle", () => {
+	it("优先用户/自动命名", () => {
+		expect(sessionTitle(meta({ name: "重构权限模块" }), "未命名会话")).toBe("重构权限模块");
+	});
+
+	it("无标题回落项目目录末级", () => {
+		expect(sessionTitle(meta({ cwd: "/work/code/ai/percho" }), "未命名会话")).toBe("percho");
+	});
+
+	it("无目录时回落未命名占位", () => {
+		expect(sessionTitle(meta({ cwd: "/" }), "Untitled")).toBe("Untitled");
+	});
+});
+
+describe("sessionProjectDir", () => {
+	it("取 cwd 末级", () => {
+		expect(sessionProjectDir(meta({ cwd: "/a/b/c" }))).toBe("c");
+		expect(sessionProjectDir(meta({ cwd: "/" }))).toBe("");
+	});
+});
+
+describe("sessionLetter", () => {
+	it("项目名首字母，无则 P", () => {
+		expect(sessionLetter(meta({ cwd: "/work/ai-ops" }))).toBe("a");
+		expect(sessionLetter(meta({ cwd: "/" }))).toBe("P");
+	});
+});

--- a/packages/desktop/src/renderer/src/components/session/session-status.ts
+++ b/packages/desktop/src/renderer/src/components/session/session-status.ts
@@ -1,0 +1,32 @@
+import type { SessionMeta } from "@percho/shared";
+import { useTranscriptStore } from "../../stores/transcript";
+
+/** 会话状态（优先级递减）：等待审批 > 工作中 > 完成未读 > 空闲。顶栏胶囊与左侧轨道共用 */
+export type SessionStatus = "attention" | "working" | "done" | "idle";
+
+/** 订阅单个会话的运行状态（selector 返回字符串原始值，引用稳定不触发多余渲染） */
+export function useSessionStatus(sessionId: string): SessionStatus {
+	return useTranscriptStore((s): SessionStatus => {
+		const entry = s.bySession[sessionId];
+		if (!entry) return "idle";
+		if (entry.pendingPermissions.length > 0) return "attention";
+		if (entry.agentActive) return "working";
+		if (entry.unseenCompletion) return "done";
+		return "idle";
+	});
+}
+
+/** 会话显示标题：用户设置/自动生成名 → 项目目录末级 → 未命名占位 */
+export function sessionTitle(session: SessionMeta, untitledLabel: string): string {
+	return session.name ?? session.cwd.split("/").filter(Boolean).pop() ?? untitledLabel;
+}
+
+/** 项目目录末级名（空串 = 无，如 cwd 为根路径） */
+export function sessionProjectDir(session: SessionMeta): string {
+	return session.cwd.split("/").filter(Boolean).pop() ?? "";
+}
+
+/** 头像字母 = 项目名（cwd 最后一段）首字母，与会话标题无关 */
+export function sessionLetter(session: SessionMeta): string {
+	return sessionProjectDir(session)[0] ?? "P";
+}

--- a/packages/desktop/src/renderer/src/components/settings/AppearancePanel.tsx
+++ b/packages/desktop/src/renderer/src/components/settings/AppearancePanel.tsx
@@ -1,6 +1,7 @@
 import type { ThemeMode } from "@percho/shared";
 import { useT } from "../../i18n";
 import { backgroundImageUrl, useThemeStore } from "../../stores/theme";
+import { useUiPreferencesStore } from "../../stores/ui-preferences";
 
 const THEME_MODES: ThemeMode[] = ["light", "dark", "system"];
 const THEME_LABEL_KEYS = {
@@ -18,6 +19,8 @@ export function AppearancePanel() {
 	const pickBackground = useThemeStore((s) => s.pickBackground);
 	const clearBackground = useThemeStore((s) => s.clearBackground);
 	const setBackgroundDim = useThemeStore((s) => s.setBackgroundDim);
+	const sessionRailEnabled = useUiPreferencesStore((s) => s.sessionRailEnabled);
+	const setSessionRailEnabled = useUiPreferencesStore((s) => s.setSessionRailEnabled);
 
 	return (
 		<div className="flex flex-col gap-6">
@@ -92,6 +95,27 @@ export function AppearancePanel() {
 						</span>
 					</div>
 				)}
+			</div>
+			<div>
+				<div className="flex items-center justify-between gap-4">
+					<h3 className="text-[13px] font-medium text-ink">{t("settings.sessionRail")}</h3>
+					<button
+						type="button"
+						role="switch"
+						aria-checked={sessionRailEnabled}
+						onClick={() => setSessionRailEnabled(!sessionRailEnabled)}
+						className={`relative h-5 w-9 shrink-0 rounded-full transition-colors ${
+							sessionRailEnabled ? "bg-ink" : "bg-border-strong"
+						}`}
+					>
+						<span
+							className={`absolute top-0.5 h-4 w-4 rounded-full bg-surface shadow transition-all ${
+								sessionRailEnabled ? "left-[18px]" : "left-0.5"
+							}`}
+						/>
+					</button>
+				</div>
+				<p className="mt-0.5 text-[11px] leading-relaxed text-ink-faint">{t("settings.sessionRailHint")}</p>
 			</div>
 		</div>
 	);

--- a/packages/desktop/src/renderer/src/i18n/en.ts
+++ b/packages/desktop/src/renderer/src/i18n/en.ts
@@ -195,6 +195,9 @@ export const en: Messages = {
 		permissionGate: "Built-in permission gate",
 		permissionGateHint:
 			"When on, tool calls are checked against rules: dangerous commands (rm -rf, sudo, force push, etc.) ask for confirmation, everything else runs. Rules live in ~/.pi/agent/permissions.json and apply instantly. Turn off to replace with your own permission extension.",
+		sessionRail: "Left session rail",
+		sessionRailHint:
+			"Shows a vertically centered track of session lines on the left of the chat view; hover or focus a line and it grows into a floating capsule (project icon + title) — click to switch. The top tab bar stays unchanged; turn off to hide it.",
 		vision: {
 			title: "Vision",
 			hint: "Adds an external vision model for text-only models: images you send are first described by the vision model, then handed to the current reasoning model. Native multimodal models skip this automatically.",

--- a/packages/desktop/src/renderer/src/i18n/zh.ts
+++ b/packages/desktop/src/renderer/src/i18n/zh.ts
@@ -192,6 +192,9 @@ export const zh = {
 		permissionGate: "内置权限门控",
 		permissionGateHint:
 			"开启后按规则拦截工具调用：高危命令（rm -rf、sudo、强推等）弹窗确认，其余放行。规则文件 ~/.pi/agent/permissions.json，修改即时生效。关闭可换用自己安装的权限扩展。",
+		sessionRail: "左侧会话轨道",
+		sessionRailHint:
+			"在聊天页左侧居中显示一列会话短线：悬停或聚焦时短线展开为悬浮胶囊（项目图标 + 会话标题），点击快速切换。顶栏会话胶囊保持不变，关闭后完全隐藏。",
 		vision: {
 			title: "视觉理解",
 			hint: "为不支持图片输入的模型外挂视觉识别：发送图片时先由视觉模型识别为文字描述，再交给当前推理模型。原生多模态模型自动跳过，不受影响。",

--- a/packages/desktop/src/renderer/src/main.tsx
+++ b/packages/desktop/src/renderer/src/main.tsx
@@ -3,6 +3,7 @@ import { createRoot } from "react-dom/client";
 import App from "./App";
 import { initSplash } from "./splash";
 import { useThemeStore } from "./stores/theme";
+import { useUiPreferencesStore } from "./stores/ui-preferences";
 import "./styles/globals.css";
 
 const root = document.getElementById("root");
@@ -11,14 +12,11 @@ if (!root) throw new Error("root element not found");
 // 开屏：同次运行已播过则立即移除，否则挂最长兜底（收場时机见 App.tsx 的 finishSplash）
 initSplash();
 
-// render 前先恢复主题/背景（一次 IPC），避免深色模式启动闪白
-void useThemeStore
-	.getState()
-	.init()
-	.finally(() => {
-		createRoot(root).render(
-			<StrictMode>
-				<App />
-			</StrictMode>,
-		);
-	});
+// render 前先恢复主题/背景/UI 偏好（一次 IPC），避免深色模式启动闪白与轨道开关闪现
+void Promise.all([useThemeStore.getState().init(), useUiPreferencesStore.getState().init()]).finally(() => {
+	createRoot(root).render(
+		<StrictMode>
+			<App />
+		</StrictMode>,
+	);
+});

--- a/packages/desktop/src/renderer/src/stores/sessions.test.ts
+++ b/packages/desktop/src/renderer/src/stores/sessions.test.ts
@@ -176,6 +176,51 @@ describe("switchSession", () => {
 	});
 });
 
+describe("reorderSessions（拖拽排序）", () => {
+	const draftMeta = (name: string): SessionMeta => ({
+		...realMeta(name, "/p"),
+		sessionId: `${DRAFT_SESSION_PREFIX}x`,
+		sessionFile: undefined,
+	});
+
+	it("向后拖：a 跨过 draft 到末尾，并按新视觉序落盘", () => {
+		useSessionsStore.setState({
+			sessions: [realMeta("a", "/p"), draftMeta("dx"), realMeta("b", "/p")],
+			cwd: "/p",
+		});
+		useSessionsStore.getState().reorderSessions("a", "b");
+		expect(useSessionsStore.getState().sessions.map((s) => s.sessionId)).toEqual([
+			`${DRAFT_SESSION_PREFIX}x`,
+			"b",
+			"a",
+		]);
+		// files 只含真实会话，顺序 = 去掉 draft 后的视觉序
+		expect(piMock.saveTabs).toHaveBeenCalledWith({
+			files: ["/tmp/b.jsonl", "/tmp/a.jsonl"],
+			activeFile: null,
+		});
+	});
+
+	it("向前拖：插入到目标原索引，中间项整体右移（arrayMove 语义，与落位视觉一致）", () => {
+		useSessionsStore.setState({ sessions: [realMeta("a", "/p"), draftMeta("dx"), realMeta("b", "/p")] });
+		useSessionsStore.getState().reorderSessions("b", "a");
+		expect(useSessionsStore.getState().sessions.map((s) => s.sessionId)).toEqual([
+			"b",
+			"a",
+			`${DRAFT_SESSION_PREFIX}x`,
+		]);
+	});
+
+	it("原地/未知 id 不变序也不落盘", () => {
+		useSessionsStore.setState({ sessions: [realMeta("a", "/p"), realMeta("b", "/p")] });
+		useSessionsStore.getState().reorderSessions("a", "a");
+		useSessionsStore.getState().reorderSessions("nope", "b");
+		useSessionsStore.getState().reorderSessions("a", "nope");
+		expect(useSessionsStore.getState().sessions.map((s) => s.sessionId)).toEqual(["a", "b"]);
+		expect(piMock.saveTabs).not.toHaveBeenCalled();
+	});
+});
+
 describe("模型/思考级别", () => {
 	it("draft 下切换模型：只更新全局默认与 draft 条目，不调后端 setModel", async () => {
 		useSessionsStore.getState().createDraftSession("/proj/a");

--- a/packages/desktop/src/renderer/src/stores/sessions.ts
+++ b/packages/desktop/src/renderer/src/stores/sessions.ts
@@ -40,6 +40,8 @@ interface SessionsStore {
 	/** 设置新会话的目标项目目录；活跃 tab 是 draft 时同步更新其条目（切 tab 往返不丢选择） */
 	setDraftCwd: (cwd: string) => void;
 	switchSession: (sessionId: string) => void;
+	/** 拖拽排序顶栏胶囊：调整 sessions 数组顺序并落盘（tabs.json 的 files 本就保序，重启按新序恢复） */
+	reorderSessions: (fromId: string, toId: string) => void;
 	closeSession: (sessionId: string) => Promise<void>;
 	openFromHistory: (filePath: string) => Promise<void>;
 	/** 在指定 assistant 消息处分叉：新会话以新 tab 打开并切换过去（原会话保留原样） */
@@ -149,6 +151,20 @@ export const useSessionsStore = create<SessionsStore>((set, get) => ({
 		set((state) => ({
 			sessions: state.sessions.map((s) => (s.sessionId === sessionId ? { ...s, name } : s)),
 		})),
+
+	reorderSessions: (fromId, toId) => {
+		const { sessions } = get();
+		const from = sessions.findIndex((s) => s.sessionId === fromId);
+		const to = sessions.findIndex((s) => s.sessionId === toId);
+		if (from < 0 || to < 0 || from === to) return;
+		const next = [...sessions];
+		const [moved] = next.splice(from, 1);
+		if (!moved) return;
+		next.splice(to, 0, moved);
+		set({ sessions: next });
+		// draft 无 sessionFile 会被过滤，落盘的是真实会话的新视觉顺序
+		persistTabs(get());
+	},
 
 	closeSession: async (sessionId) => {
 		const isDraft = isDraftSessionId(sessionId);

--- a/packages/desktop/src/renderer/src/stores/ui-preferences.test.ts
+++ b/packages/desktop/src/renderer/src/stores/ui-preferences.test.ts
@@ -1,0 +1,43 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+/** window.pi 的 mock：ui-preferences store 经 getPi() 访问，测试环境无 preload 注入 */
+const piMock = vi.hoisted(() => ({
+	loadUiState: vi.fn(),
+	saveUiState: vi.fn(),
+}));
+vi.mock("../api", () => ({ getPi: () => piMock }));
+
+import { useUiPreferencesStore } from "./ui-preferences";
+
+beforeEach(() => {
+	vi.clearAllMocks();
+	useUiPreferencesStore.setState({ sessionRailEnabled: false });
+});
+
+describe("useUiPreferencesStore", () => {
+	it("默认关闭（旧版本 ui-state 无该字段）", () => {
+		expect(useUiPreferencesStore.getState().sessionRailEnabled).toBe(false);
+	});
+
+	it("init 从 ui-state 恢复开关", async () => {
+		piMock.loadUiState.mockResolvedValue({ sessionRailEnabled: true });
+		await useUiPreferencesStore.getState().init();
+		expect(useUiPreferencesStore.getState().sessionRailEnabled).toBe(true);
+	});
+
+	it("init 加载失败或字段缺失时回落默认关闭", async () => {
+		piMock.loadUiState.mockRejectedValue(new Error("no file"));
+		await useUiPreferencesStore.getState().init();
+		expect(useUiPreferencesStore.getState().sessionRailEnabled).toBe(false);
+
+		piMock.loadUiState.mockResolvedValue({});
+		await useUiPreferencesStore.getState().init();
+		expect(useUiPreferencesStore.getState().sessionRailEnabled).toBe(false);
+	});
+
+	it("切换开关即持久化补丁", () => {
+		useUiPreferencesStore.getState().setSessionRailEnabled(true);
+		expect(useUiPreferencesStore.getState().sessionRailEnabled).toBe(true);
+		expect(piMock.saveUiState).toHaveBeenCalledWith({ sessionRailEnabled: true });
+	});
+});

--- a/packages/desktop/src/renderer/src/stores/ui-preferences.ts
+++ b/packages/desktop/src/renderer/src/stores/ui-preferences.ts
@@ -1,0 +1,27 @@
+import { create } from "zustand";
+import { getPi } from "../api";
+
+/** 应用级 UI 偏好（持久化在 ui-state.json，与主题/背景同源；主进程 normalize 负责旧文件缺省） */
+interface UiPreferencesStore {
+	/** 左侧会话轨道：聊天页左侧短线悬停展开标题，快速切换会话（默认关，顶栏胶囊不受影响） */
+	sessionRailEnabled: boolean;
+	/** 启动时从 ui-state.json 恢复（main.tsx 在 render 前 await，避免开关状态闪现） */
+	init: () => Promise<void>;
+	setSessionRailEnabled: (enabled: boolean) => void;
+}
+
+export const useUiPreferencesStore = create<UiPreferencesStore>((set) => ({
+	sessionRailEnabled: false,
+
+	init: async () => {
+		const saved = await getPi()
+			.loadUiState()
+			.catch(() => null);
+		set({ sessionRailEnabled: saved?.sessionRailEnabled ?? false });
+	},
+
+	setSessionRailEnabled: (enabled) => {
+		set({ sessionRailEnabled: enabled });
+		void getPi().saveUiState({ sessionRailEnabled: enabled });
+	},
+}));

--- a/packages/desktop/src/renderer/src/styles/globals.css
+++ b/packages/desktop/src/renderer/src/styles/globals.css
@@ -311,6 +311,167 @@
 	}
 }
 
+/* 左侧会话轨道（设置 → 外观开关，可选交互）：聊天页左侧垂直居中一列**直角细线**（codex 风），
+   悬停/聚焦时原地「变形」为悬浮胶囊，上下邻居按行距分级跟涨成**半大/迷你胶囊**（dock 波浪：
+   展开 208×32 → ±1 胶囊 104×24（内容可见、标题裁断） → ±2 迷你空胶囊 44×14 → 细线），
+   状态类 is-expanded/is-near-1/is-near-2 由 JS 按行距下发（比 :has 链易控：呼吸/内容显隐按距离精确开关）。
+   **行高同步分级撑开（16 → 40/32/20 = 胶囊 + 留白）**：按钮在文档流内，行一撑上下邻居自然让位，
+   胶囊各行其道互不叠压；行高与胶囊同时长同曲线伸缩，任何时刻胶囊都不会超出行。
+   变形是两阶段时序（transition 取「目标态」的定义，正反向可分别配时序）：
+   展开/跟涨 = 先在小尺寸上 90ms 翻色/翻圆角（深色线 → 白胶囊），再回弹放大（340/300/280ms 随档位递减）；
+   收起 = 先 260ms 收缩（仍是白胶囊），颜色/圆角延迟 150ms 到接近尾声才变回细线。
+   避免旧版「深色线拉长到一半才闪白」的颜色逆变闪烁。 */
+/* 行高波浪：transition 同样取目标态定义（收起走基线 260ms） */
+.session-rail-item {
+	transition: height 260ms cubic-bezier(0.34, 1.15, 0.64, 1);
+}
+.session-rail-item.is-expanded {
+	height: 40px;
+	transition: height 340ms cubic-bezier(0.34, 1.25, 0.64, 1);
+}
+.session-rail-item.is-near-1 {
+	height: 32px;
+	transition: height 300ms cubic-bezier(0.34, 1.25, 0.64, 1);
+}
+.session-rail-item.is-near-2 {
+	height: 20px;
+	transition: height 280ms cubic-bezier(0.34, 1.25, 0.64, 1);
+}
+.session-rail-item .rail-capsule {
+	position: absolute;
+	left: 6px;
+	top: 50%;
+	display: flex;
+	align-items: center;
+	/* 无 padding：否则 border-box 下收起态高度被 padding 撑成 12px，就不是一条线了。
+	   内距在内容包裹层（JSX 的 px-2.5），收起时随内容一起被 overflow 裁掉 */
+	border-radius: 0;
+	overflow: hidden;
+	transform: translateY(-50%);
+	/* 收起（目标态 = 细线）：尺寸先走，颜色/圆角延迟到收缩近尾声再翻 */
+	transition:
+		width 260ms cubic-bezier(0.34, 1.15, 0.64, 1),
+		height 260ms cubic-bezier(0.34, 1.15, 0.64, 1),
+		background-color 80ms ease 150ms,
+		border-radius 80ms ease 150ms,
+		box-shadow 120ms ease;
+}
+/* 波浪档位 z 序：展开浮最上，±1 压 ±2 压细线（胶囊比行距大，会覆盖邻行） */
+.session-rail-item.is-expanded {
+	z-index: 10;
+}
+.session-rail-item.is-near-1 {
+	z-index: 6;
+}
+.session-rail-item.is-near-2 {
+	z-index: 4;
+}
+.session-rail-item.is-expanded .rail-capsule {
+	/* 与顶栏胶囊同宽（w-52）；窄窗口按视口收缩，不越过右缘 */
+	width: min(208px, calc(100vw - 40px));
+	height: 32px;
+	border-radius: 9999px;
+	background-color: var(--color-surface);
+	box-shadow: var(--shadow-pop);
+	/* 展开（目标态 = 胶囊）：颜色/圆角 90ms 先行（趁尺寸还小），尺寸随后 340ms 回弹放大，阴影最后到 */
+	transition:
+		width 340ms cubic-bezier(0.34, 1.25, 0.64, 1),
+		height 340ms cubic-bezier(0.34, 1.25, 0.64, 1),
+		background-color 90ms ease,
+		border-radius 90ms ease,
+		box-shadow 220ms ease 80ms;
+}
+/* ±1：一半大的胶囊（104×24），头像+标题可见（裁断出预览感），柔阴影 */
+.session-rail-item.is-near-1 .rail-capsule {
+	width: 104px;
+	height: 24px;
+	border-radius: 9999px;
+	background-color: var(--color-surface);
+	box-shadow: var(--shadow-soft);
+	transition:
+		width 300ms cubic-bezier(0.34, 1.25, 0.64, 1),
+		height 300ms cubic-bezier(0.34, 1.25, 0.64, 1),
+		background-color 90ms ease 20ms,
+		border-radius 90ms ease 20ms,
+		box-shadow 180ms ease 60ms;
+}
+/* ±2：迷你空胶囊（44×14），纯波形过渡元素，不显示内容 */
+.session-rail-item.is-near-2 .rail-capsule {
+	width: 44px;
+	height: 14px;
+	border-radius: 9999px;
+	background-color: var(--color-surface);
+	box-shadow: var(--shadow-soft);
+	transition:
+		width 280ms cubic-bezier(0.34, 1.25, 0.64, 1),
+		height 280ms cubic-bezier(0.34, 1.25, 0.64, 1),
+		background-color 90ms ease 20ms,
+		border-radius 90ms ease 20ms,
+		box-shadow 150ms ease 50ms;
+}
+/* 胶囊内容（图标 + 标题）：展开/±1 时等翻色完成后渐入，配合裁剪逐步揭示；
+   收起/进 ±2 时 120ms 淡出（快于收缩），不留空胶囊 */
+.session-rail-item .rail-capsule > * {
+	opacity: 0;
+	transition: opacity 120ms ease;
+}
+.session-rail-item.is-expanded .rail-capsule > * {
+	opacity: 1;
+	transition: opacity 180ms ease 110ms;
+}
+.session-rail-item.is-near-1 .rail-capsule > * {
+	opacity: 1;
+	transition: opacity 160ms ease 70ms;
+}
+/* 胶囊末尾的关闭 ×：仅展开态可见可点（同顶栏 group-hover 语义；±1/±2 只是波浪预览不给操作），
+   点击 stopPropagation 不触发切换；closeSession 后顶栏/轨道同读 sessions 数组，天然双向同步。
+   宽度 0→16 与胶囊同曲线「长出来」（margin-left 负值抵消 gap），±1 预览标题不被挤占 */
+.session-rail-item .rail-close {
+	width: 0;
+	margin-left: -8px;
+	opacity: 0;
+	pointer-events: none;
+	transition:
+		width 260ms cubic-bezier(0.34, 1.15, 0.64, 1),
+		margin-left 260ms cubic-bezier(0.34, 1.15, 0.64, 1),
+		opacity 100ms ease;
+}
+.session-rail-item.is-expanded .rail-close {
+	width: 16px;
+	margin-left: 0;
+	opacity: 1;
+	pointer-events: auto;
+	transition:
+		width 340ms cubic-bezier(0.34, 1.25, 0.64, 1),
+		margin-left 340ms cubic-bezier(0.34, 1.25, 0.64, 1),
+		opacity 180ms ease 110ms;
+}
+/* 呼吸只作用于收起态的细线；展开/跟涨成白胶囊后由内部头像的 tab-avatar-working 承担（整个白胶囊闪透明度会像故障） */
+.session-rail-item:not(.is-expanded):not(.is-near-1):not(.is-near-2) .rail-working {
+	animation: avatar-breathe 3.2s ease-in-out infinite;
+}
+@media (prefers-reduced-motion: reduce) {
+	/* 各档位 transition 定义在更高优先级的状态选择器里，必须逐档同优先级覆盖才压得住 */
+	.session-rail-item,
+	.session-rail-item.is-expanded,
+	.session-rail-item.is-near-1,
+	.session-rail-item.is-near-2,
+	.session-rail-item .rail-capsule,
+	.session-rail-item.is-expanded .rail-capsule,
+	.session-rail-item.is-near-1 .rail-capsule,
+	.session-rail-item.is-near-2 .rail-capsule,
+	.session-rail-item .rail-capsule > *,
+	.session-rail-item.is-expanded .rail-capsule > *,
+	.session-rail-item.is-near-1 .rail-capsule > *,
+	.session-rail-item .rail-close,
+	.session-rail-item.is-expanded .rail-close {
+		transition: none;
+	}
+	.session-rail-item:not(.is-expanded):not(.is-near-1):not(.is-near-2) .rail-working {
+		animation: none;
+	}
+}
+
 html,
 body,
 #root {
@@ -439,6 +600,8 @@ code {
 /* markstream-react 视觉覆写：组件样式均为 :where() 零优先级，此处规则必覆盖；对齐原 react-markdown 设计 */
 .markdown-body {
 	--link-color: var(--color-accent);
+	/* 库的 rounded-lg 等工具类吃 --ms-radius，CSS 里无默认定义（→ 直角）；在此补上 */
+	--ms-radius: 10px;
 }
 .markdown-body .paragraph-node {
 	margin: 0.375rem 0;
@@ -493,12 +656,80 @@ code {
 	text-decoration-color: var(--markdown-link-decoration);
 	text-underline-offset: auto;
 }
+/* 代码块容器：边框/阴影 token 化（库默认 gray-200/gray-700 硬编码 + shadow-sm） */
+.markdown-body .code-block-container {
+	border-color: var(--color-border);
+	box-shadow: var(--shadow-soft);
+}
+/* 代码块「纯净化」：标题栏悬浮 —— 常态隐身（纯代码），hover / 键盘聚焦 / 折叠态时浮现。
+   header DOM 必须保留（折叠/复制按钮逻辑都在里面，折叠是组件内部 state 外部无法控制，
+   showHeader:false 会把按钮一起去掉），多余按钮已在 Markdown.tsx 经 codeBlockProps 关闭。
+   组件把 header 背景用 inline style 钉成编辑器主题色，需 !important 压掉。 */
+.markdown-body .code-block-container .code-block-header {
+	position: absolute;
+	top: 0;
+	left: 0;
+	right: 0;
+	z-index: 2;
+	padding: 0.5rem 0.625rem;
+	/* biome-ignore lint/complexity/noImportantStyles: 必须压过组件 inline style 的 background-color: var(--vscode-editor-background) */
+	background: transparent !important;
+	border-bottom: none;
+	opacity: 0;
+	pointer-events: none;
+	transition: opacity 0.18s ease;
+}
+.markdown-body .code-block-container:hover .code-block-header,
+.markdown-body .code-block-container:focus-within .code-block-header,
+/* 折叠后内容区整个卸载，悬浮条必须常显才能再展开（此时只剩折叠钮有 aria-pressed） */
+	.markdown-body
+	.code-block-container:has(.code-action-btn[aria-pressed="true"])
+	.code-block-header {
+	opacity: 1;
+	pointer-events: auto;
+}
+/* 折叠态容器会塌成 0 高，给悬浮条留最小可点击高度 */
+.markdown-body .code-block-container:has(.code-action-btn[aria-pressed="true"]) {
+	min-height: 44px;
+}
+/* 悬浮语言标签与按钮：半透明胶囊 + 毛玻璃，颜色全走 token 自动适配深浅 */
+.markdown-body .code-block-header > div:first-child,
+.markdown-body .code-block-header .code-action-btn {
+	border: 1px solid var(--color-border);
+	border-radius: 6px;
+	background: color-mix(in srgb, var(--color-canvas) 72%, transparent);
+	backdrop-filter: blur(8px);
+}
+.markdown-body .code-block-header > div:first-child {
+	flex: none; /* 盖掉库 flex-1：否则语言胶囊撑满整条通栏 */
+	padding: 0.125rem 0.5rem;
+	color: var(--color-ink-dim);
+}
+/* 语言名（库渲染为无语义类的 span.text-sm.font-mono） */
+.markdown-body .code-block-header > div:first-child > span:last-child {
+	font-size: 11px;
+	letter-spacing: 0.03em;
+}
+.markdown-body .code-block-header .code-action-btn {
+	padding: 0.25rem;
+}
+@media (prefers-reduced-motion: reduce) {
+	.markdown-body .code-block-container .code-block-header {
+		transition: none;
+	}
+}
+/* header 右侧图标按钮：颜色继承自容器（= 编辑器主题前景），只需抹平深蓝底文字按钮 */
+.markdown-body .code-block-btn {
+	border-color: var(--color-border-strong);
+	background: var(--color-surface);
+	color: var(--color-ink-2);
+}
 /* 抹平 markstream-react 自带的默认 hover（非我们的设计）：代码块头部按钮变蓝、action 按钮透明度跳变、
    mermaid 按钮/关闭键变色、脚注 hover 下划线。统一 hover = 常态 */
 .markdown-body .code-block-btn:hover {
-	background: #0f172a99;
-	border-color: rgba(148, 163, 184, 0.4);
-	color: #f8fafc;
+	background: var(--color-hover);
+	border-color: var(--color-border-strong);
+	color: var(--color-ink);
 }
 .markdown-body .code-action-btn:hover {
 	opacity: 0.7;
@@ -519,6 +750,13 @@ code {
 	background: transparent;
 	color: inherit;
 	opacity: 0.9;
+}
+/* monaco 就绪前/失败时的纯文本 fallback：库默认 font-family/background 全 inherit（混入正文体），
+   补齐等宽字体与主题色表面，加载瞬间不突兀 */
+.markdown-body .code-fallback-plain {
+	font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace;
+	font-size: 12.5px;
+	padding: 0.75rem 1rem;
 }
 .markdown-body .inline-code {
 	padding: 0.125rem 0.25rem;

--- a/packages/desktop/src/renderer/src/styles/globals.css
+++ b/packages/desktop/src/renderer/src/styles/globals.css
@@ -280,6 +280,37 @@
 	}
 }
 
+/* 会话胶囊拖拽排序：tab-pill 是内层视觉层（拾起 scale + 上浮 + 阴影，160ms 独立过渡；
+   opacity 同表：拖拽时本体淡出交由 DragOverlay ghost，落位时淡入，与 ghost fade 交叉）。
+   几何层的 translate/让位/FLIP 由 dnd-kit 内联 style 控制（见 SessionTabBar），两层互不干扰；
+   全程只动 transform/box-shadow/opacity，合成器友好 */
+.tab-pill {
+	transition:
+		transform 160ms cubic-bezier(0.2, 0, 0, 1),
+		box-shadow 160ms cubic-bezier(0.2, 0, 0, 1),
+		opacity 160ms ease;
+}
+.tab-dragging {
+	transform: scale(1.045) translateY(-1px);
+	box-shadow:
+		0 6px 18px rgb(0 0 0 / 0.18),
+		0 0 0 1px rgb(0 0 0 / 0.05);
+}
+/* 拖拽期间指针常在胶囊间隙上，cursor 挂根元素统一接管。
+   不用 !important：Tailwind 工具类在 @layer utilities，未分层规则天然优先 */
+.tab-dragging-cursor,
+.tab-dragging-cursor * {
+	cursor: grabbing;
+}
+@media (prefers-reduced-motion: reduce) {
+	.tab-pill {
+		transition: none;
+	}
+	.tab-dragging {
+		transform: none;
+	}
+}
+
 html,
 body,
 #root {

--- a/packages/shared/src/ipc.ts
+++ b/packages/shared/src/ipc.ts
@@ -155,12 +155,12 @@ export interface PiApi {
 	/**
 	 * 在指定 assistant 消息处分叉：生成以其为结尾的新会话并切换过去（原会话文件保留）。
 	 * ref.entryId 精确定位（历史消息）；缺省时按 ref.text 从分支尾部匹配最近一条同文 assistant 消息。
-	 * 运行中的会话拒绝 fork。返回新会话 meta。
+	 * 运行或压缩中的会话拒绝 fork。返回新会话 meta。
 	 */
 	forkSession(sessionId: string, ref: { entryId?: string; text?: string }): Promise<SessionMeta>;
 	/**
 	 * 撤回一条用户消息：会话回退到该消息发送之前（被撤回内容在文件中保留为侧枝），
-	 * 文本与图片返回给调用方放回输入框。运行中的会话拒绝撤回。
+	 * 文本与图片返回给调用方放回输入框。运行或压缩中的会话拒绝撤回。
 	 */
 	recallMessage(
 		sessionId: string,

--- a/packages/shared/src/session.ts
+++ b/packages/shared/src/session.ts
@@ -22,6 +22,8 @@ export interface UiState {
 	thinkingLevel: string;
 	theme: ThemeMode;
 	background: BackgroundSettings;
+	/** 左侧会话轨道开关（聊天页左侧短线悬停展开标题，见 SessionRail；旧版本文件缺省为 false） */
+	sessionRailEnabled: boolean;
 }
 
 /** 会话元数据（IPC 往返用，独立于 pi 内部类型） */

--- a/scripts/shoot-rail.mjs
+++ b/scripts/shoot-rail.mjs
@@ -1,0 +1,168 @@
+/**
+ * SessionRail 波浪动画逐帧截图（确定性 scrub，非实时抓拍）
+ *
+ * 原理：
+ * - CDP `Page.captureScreenshot` 拿的是 Chromium 合成器的页面表面（纯 DOM 渲染结果），
+ *   不经过屏幕、不需要录屏权限、不怕窗口遮挡，比 macOS screencapture 准且无干扰。
+ * - `document.getAnimations()` 能拿到所有 CSS transition/animation，pause 后用
+ *   `currentTime` 把动画时钟钉在指定毫秒 —— 每一帧都是精确时刻，零竞态。
+ *
+ * 前置：dev 应用带调试端口运行：npm run dev -- --remote-debugging-port=9224
+ *   （且设置 → 外观 已打开左侧会话轨道、顶栏有 ≥3 个会话；
+ *     或预先 seed userData/tabs.json + ui-state.json，见本目录 git 历史）
+ *
+ * 用法：
+ *   node scripts/shoot-rail.mjs [phase] [outDir]
+ *   phase = enter（悬停展开，默认）| leave（移开收起）| sweep（相邻项划过，波浪移动）| all
+ *   例：node scripts/shoot-rail.mjs all /tmp/rail-frames
+ */
+import { execSync } from "node:child_process";
+import { mkdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+const phase = process.argv[2] ?? "all";
+const outDir = process.argv[3] ?? "/tmp/rail-frames";
+mkdirSync(outDir, { recursive: true });
+
+/* 帧采样点（ms）：展开尺寸 340ms + 阴影 220+80ms + 内容 180+110ms，全覆盖到 520 */
+const ENTER_TIMES = [0, 30, 60, 90, 120, 160, 200, 240, 280, 320, 360, 400, 450, 520];
+/* 收起 260ms + 翻色延迟 150+80ms */
+const LEAVE_TIMES = [0, 40, 80, 120, 160, 200, 240, 300];
+/* 划过 = 旧项 expanded→±1 收缩 300ms + 新项 ±1→expanded 340ms */
+const SWEEP_TIMES = [0, 40, 80, 120, 160, 200, 240, 280, 340, 420];
+
+/* ---------- CDP 连接 ---------- */
+const listJson = execSync("curl -s http://127.0.0.1:9224/json").toString();
+const page = JSON.parse(listJson).find((x) => x.type === "page");
+if (!page) {
+	console.error("没有找到 page target，dev 应用是否在 9224 端口运行？");
+	process.exit(1);
+}
+const { WebSocket } = await import("ws");
+const ws = new WebSocket(page.webSocketDebuggerUrl);
+let msgId = 0;
+const pending = new Map();
+ws.on("message", (data) => {
+	const msg = JSON.parse(data.toString());
+	if (msg.id && pending.has(msg.id)) {
+		pending.get(msg.id)(msg);
+		pending.delete(msg.id);
+	}
+});
+await new Promise((r) => ws.on("open", r));
+function send(method, params = {}) {
+	return new Promise((resolve, reject) => {
+		const id = ++msgId;
+		pending.set(id, (msg) => (msg.error ? reject(new Error(msg.error.message)) : resolve(msg.result)));
+		ws.send(JSON.stringify({ id, method, params }));
+	});
+}
+async function evalJs(expression) {
+	const result = await send("Runtime.evaluate", {
+		expression,
+		returnByValue: true,
+		awaitPromise: true,
+	});
+	if (result.exceptionDetails) {
+		throw new Error(`页面内执行失败: ${JSON.stringify(result.exceptionDetails, null, 2)}`);
+	}
+	return result.result?.value;
+}
+/* 合成器偶发给出整帧纯色空白（PNG 极度压缩后仅几 KB，正常帧 ≥15KB），
+   动画是暂停钉死状态的，等一拍重截同一帧是确定性的；12KB 阈值 + 最多 3 次 */
+async function shot(name, clip) {
+	for (let attempt = 1; attempt <= 3; attempt++) {
+		const { data } = await send("Page.captureScreenshot", { format: "png", clip });
+		const buf = Buffer.from(data, "base64");
+		if (buf.length > 12000) {
+			writeFileSync(join(outDir, `${name}.png`), buf);
+			console.log(`  ${name}.png${attempt > 1 ? `（重试 ${attempt - 1} 次后成功）` : ""}`);
+			return;
+		}
+		await new Promise((r) => setTimeout(r, 150));
+	}
+	console.log(`  ${name}.png ⚠ 3 次都是空白帧，已跳过`);
+}
+
+/* ---------- 页面内动作 ---------- */
+
+/** 触发悬停/移开并冻结新产生的动画：pause 全部，无限动画（呼吸）钉在 50% 相位（不透明），
+ *  有限动画记录各自 base currentTime 挂到 window.__railAnims 供逐帧 scrub */
+const beginAction = `(async (idx, enter) => {
+	const items = [...document.querySelectorAll(".session-rail-item")];
+	if (items.length < 3) throw new Error("轨道项不足（<3），先开几个会话并打开轨道开关");
+	const el = items[idx];
+	el.dispatchEvent(new MouseEvent(enter ? "mouseover" : "mouseout", { bubbles: true }));
+	// React 状态 flush + transition 创建
+	await new Promise((r) => requestAnimationFrame(() => requestAnimationFrame(r)));
+	const anims = document.getAnimations().filter((a) => a.playState !== "idle");
+	for (const a of anims) a.pause();
+	window.__railAnims = anims.map((a) => {
+		const timing = a.effect?.getTiming?.() ?? {};
+		const infinite = timing.iterations === Infinity;
+		if (infinite) a.currentTime = 1600; // avatar-breathe 50% = 全不透明，帧间不闪
+		return { anim: a, base: infinite ? null : (a.currentTime ?? 0) };
+	});
+	return { count: items.length, anims: window.__railAnims.length };
+})`;
+
+/** 把所有有限动画钉在 base + t 毫秒，等一帧让合成器出新画面 */
+const scrubTo = `(async (t) => {
+	for (const { anim, base } of window.__railAnims ?? []) {
+		if (base !== null) anim.currentTime = base + t;
+	}
+	await new Promise((r) => requestAnimationFrame(r));
+	return true;
+})`;
+
+/** 目标项中心附近的裁剪区（CSS 像素）：覆盖 ±2 以上及以下各数行 */
+const clipOf = `(async (idx) => {
+	const items = [...document.querySelectorAll(".session-rail-item")];
+	const r = items[idx].getBoundingClientRect();
+	const cy = r.top + r.height / 2;
+	return { x: 0, y: Math.max(0, Math.round(cy - 112)), width: 340, height: 224, scale: 1 };
+})`;
+
+async function captureSequence(tag, idx, enter, times) {
+	const info = await evalJs(`${beginAction}(${idx}, ${enter})`);
+	console.log(`${tag}: ${info.count} 项, ${info.anims} 个动画已冻结`);
+	const clip = await evalJs(`${clipOf}(${idx})`);
+	for (const t of times) {
+		await evalJs(`${scrubTo}(${t})`);
+		await shot(`${tag}-t${String(t).padStart(3, "0")}`, clip);
+	}
+}
+
+/* ---------- 主流程 ---------- */
+const targetIndex = await evalJs(
+	`(async () => Math.floor(document.querySelectorAll(".session-rail-item").length / 2))()`,
+);
+console.log(`目标项 index = ${targetIndex}`);
+
+if (phase === "enter" || phase === "all") {
+	await captureSequence("enter", targetIndex, true, ENTER_TIMES);
+}
+if (phase === "leave" || phase === "all") {
+	// 从完全展开态出发：先悬停并直接跳到终点
+	if (phase === "leave") {
+		await evalJs(`${beginAction}(${targetIndex}, true)`);
+		await evalJs(`${scrubTo}(600)`);
+	}
+	await captureSequence("leave", targetIndex, false, LEAVE_TIMES);
+}
+if (phase === "sweep" || phase === "all") {
+	// 先完全展开 targetIndex，再划到下一项：旧项 expanded→±1、新项 ±1→expanded
+	await evalJs(`${beginAction}(${targetIndex}, true)`);
+	await evalJs(`${scrubTo}(600)`);
+	await captureSequence("sweep", targetIndex + 1, true, SWEEP_TIMES);
+}
+
+/* 收尾：恢复动画播放（转到终态/呼吸继续），页面不留冰冻状态 */
+await evalJs(`(() => {
+	for (const { anim } of window.__railAnims ?? []) anim.play();
+	window.__railAnims = null;
+	return true;
+})()`);
+ws.close();
+console.log(`完成 → ${outDir}`);
+process.exit(0);


### PR DESCRIPTION
## 概要

顶栏会话胶囊支持拖拽排序（浏览器标签式手感），方便把同一项目的会话放在一起。顺序随 tabs.json 持久化，重启按新序恢复。

## 交互

- 按住拖动 5px 拾起（scale 1.045 + 上浮 + 阴影），松手落位；原地点击/关胶囊不受影响
- 邻居让位 + 落位 FLIP：220ms `cubic-bezier(0.2,0,0,1)` 减速曲线
- 拖到条两端自动横向滚动；键盘 Space 抬起 + 方向键移动（a11y）
- `prefers-reduced-motion` 全关

## 实现要点（踩坑记录）

- **DragOverlay ghost（fixed 定位）而非流内 transform**：Chromium 会把 transform 后的流内盒子计入滚动容器可滚动区域，指针跟随 transform 会无限撑大 scrollWidth → auto-scroll 追着新边缘滚 = 右向无限滚动；ghost 不参与滚动区域，根治
- **轴锁定 modifiers 挂 DragOverlay**（`restrictToHorizontalAxis` + `restrictToParentElement`）：垂直分量恒 0；否则垂直位移会让 closestCenter 的 over 在相邻项间翻转 = 邻居让位抖动
- **transition 严格按 dnd-kit 协议应用**：自定义节奏经 `useSortable({ transition })` 参数传入，hook 返回值（含 FLIP 布点的 `"none"` 帧）原样应用——覆盖 "none" 帧会导致落位时让位胶囊左闪再回弹
- **拖拽期间顶栏临时退出 `drag-region`**：胶囊间隙本是窗口拖拽区，否则被 macOS 当拖窗口吞指针事件
- 拖拽中的源胶囊 opacity 0（保留布局槽位供让位计算），落位与 ghost fade 交叉淡入
- `sessions` store 新增 `reorderSessions`：arrayMove 语义换序 + `persistTabs`（draft 无 sessionFile 只参与内存序）

## 依赖

+`@dnd-kit/core@6.3` `@dnd-kit/sortable@10` `@dnd-kit/modifiers@9`（合成器友好的 transform 驱动，无 framer-motion 体积负担）

## 验证

- [x] `npm run lint`（0 warning）/ `typecheck` / `test`（283 通过，含 4 个新 reorderSessions 用例）/ `build`
- [x] 左右拖动落位无回闪；右拖到内容末尾即停（与左边界对称）；垂直拖动胶囊不动、无抖动
- [x] 重启后顺序保持

> 本 PR 暂不合并——后续还有相关改动，攒一批一起合。