### PR TITLE
feat: 顶栏会话胶囊拖拽排序（浏览器标签式）

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -952,6 +952,73 @@
 				"node": ">=14.21.3"
 			}
 		},
+		"node_modules/@dnd-kit/accessibility": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmmirror.com/@dnd-kit/accessibility/-/accessibility-3.1.1.tgz",
+			"integrity": "sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==",
+			"license": "MIT",
+			"dependencies": {
+				"tslib": "^2.0.0"
+			},
+			"peerDependencies": {
+				"react": ">=16.8.0"
+			}
+		},
+		"node_modules/@dnd-kit/core": {
+			"version": "6.3.1",
+			"resolved": "https://registry.npmmirror.com/@dnd-kit/core/-/core-6.3.1.tgz",
+			"integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@dnd-kit/accessibility": "^3.1.1",
+				"@dnd-kit/utilities": "^3.2.2",
+				"tslib": "^2.0.0"
+			},
+			"peerDependencies": {
+				"react": ">=16.8.0",
+				"react-dom": ">=16.8.0"
+			}
+		},
+		"node_modules/@dnd-kit/modifiers": {
+			"version": "9.0.0",
+			"resolved": "https://registry.npmmirror.com/@dnd-kit/modifiers/-/modifiers-9.0.0.tgz",
+			"integrity": "sha512-ybiLc66qRGuZoC20wdSSG6pDXFikui/dCNGthxv4Ndy8ylErY0N3KVxY2bgo7AWwIbxDmXDg3ylAFmnrjcbVvw==",
+			"license": "MIT",
+			"dependencies": {
+				"@dnd-kit/utilities": "^3.2.2",
+				"tslib": "^2.0.0"
+			},
+			"peerDependencies": {
+				"@dnd-kit/core": "^6.3.0",
+				"react": ">=16.8.0"
+			}
+		},
+		"node_modules/@dnd-kit/sortable": {
+			"version": "10.0.0",
+			"resolved": "https://registry.npmmirror.com/@dnd-kit/sortable/-/sortable-10.0.0.tgz",
+			"integrity": "sha512-+xqhmIIzvAYMGfBYYnbKuNicfSsk4RksY2XdmJhT+HAC01nix6fHCztU68jooFiMUB01Ky3F0FyOvhG/BZrWkg==",
+			"license": "MIT",
+			"dependencies": {
+				"@dnd-kit/utilities": "^3.2.2",
+				"tslib": "^2.0.0"
+			},
+			"peerDependencies": {
+				"@dnd-kit/core": "^6.3.0",
+				"react": ">=16.8.0"
+			}
+		},
+		"node_modules/@dnd-kit/utilities": {
+			"version": "3.2.2",
+			"resolved": "https://registry.npmmirror.com/@dnd-kit/utilities/-/utilities-3.2.2.tgz",
+			"integrity": "sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==",
+			"license": "MIT",
+			"dependencies": {
+				"tslib": "^2.0.0"
+			},
+			"peerDependencies": {
+				"react": ">=16.8.0"
+			}
+		},
 		"node_modules/@earendil-works/pi-ai": {
 			"version": "0.84.0",
 			"resolved": "https://registry.npmmirror.com/@earendil-works/pi-ai/-/pi-ai-0.84.0.tgz",
@@ -10435,6 +10502,9 @@
 			"version": "0.3.5",
 			"license": "MIT",
 			"dependencies": {
+				"@dnd-kit/core": "^6.3.1",
+				"@dnd-kit/modifiers": "^9.0.0",
+				"@dnd-kit/sortable": "^10.0.0",
 				"@earendil-works/pi-ai": "0.84.0",
 				"@earendil-works/pi-coding-agent": "0.84.0",
 				"@percho/backend": "*",

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -16,6 +16,9 @@
 		"start": "electron-vite preview"
 	},
 	"dependencies": {
+		"@dnd-kit/core": "^6.3.1",
+		"@dnd-kit/modifiers": "^9.0.0",
+		"@dnd-kit/sortable": "^10.0.0",
 		"@earendil-works/pi-ai": "0.84.0",
 		"@earendil-works/pi-coding-agent": "0.84.0",
 		"@percho/backend": "*",

--- a/packages/desktop/src/renderer/src/components/session/SessionTabBar.tsx
+++ b/packages/desktop/src/renderer/src/components/session/SessionTabBar.tsx
@@ -1,5 +1,23 @@
+import type { DragEndEvent, Modifier } from "@dnd-kit/core";
+import {
+	closestCenter,
+	DndContext,
+	DragOverlay,
+	KeyboardSensor,
+	PointerSensor,
+	useSensor,
+	useSensors,
+} from "@dnd-kit/core";
+import { restrictToHorizontalAxis, restrictToParentElement } from "@dnd-kit/modifiers";
+import {
+	horizontalListSortingStrategy,
+	SortableContext,
+	sortableKeyboardCoordinates,
+	useSortable,
+} from "@dnd-kit/sortable";
 import type { SessionMeta } from "@percho/shared";
-import { useEffect, useRef } from "react";
+import type { ComponentProps } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useT } from "../../i18n";
 import { useSessionsStore } from "../../stores/sessions";
 import { useTranscriptStore } from "../../stores/transcript";
@@ -10,12 +28,45 @@ import { UpdateButton } from "./UpdateButton";
 /** tab 状态（优先级递减）：等待权限 > 工作中 > 完成未读 > 空闲 */
 type TabStatus = "attention" | "working" | "done" | "idle";
 
-/** 单个会话 tab：独立订阅自己的运行状态（切走后状态不丢） */
-function SessionTab({ session, isActive }: { session: SessionMeta; isActive: boolean }) {
+/** 拖拽让位/落位的减速曲线（浏览器标签同款手感） */
+const SORT_EASE = "cubic-bezier(0.2, 0, 0, 1)";
+
+/** 拖拽轴锁定（挂在 DragOverlay 上）：只许水平移动，且钳在 tab 条容器内（浏览器标签行为）。
+ *  必须挂 overlay：ghost 是 fixed 定位不参与滚动区域；若让指针 transform 落在流内胶囊上，
+ *  Chromium 会把 transform 后的盒子计入滚动容器的可滚动区域 → 拖到右缘 scrollWidth 持续增长，
+ *  auto-scroll 追着新边缘滚 = 无限右滚（左侧有 scrollLeft>=0 天然边界所以没事） */
+const DRAG_MODIFIERS: Modifier[] = [restrictToHorizontalAxis, restrictToParentElement];
+
+/** ghost 落位动画：fade 回到槽位（duration 用自己的曲线节奏） */
+const DROP_ANIMATION = { duration: 180, easing: SORT_EASE };
+
+const prefersReducedMotion = (): boolean => window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+
+/** 拖拽中的全局 cursor（指针常在胶囊外的间隙上，须挂在根元素） */
+function setDraggingCursor(on: boolean): void {
+	document.documentElement.classList.toggle("tab-dragging-cursor", on);
+}
+
+/** 胶囊视觉（presentational）：真实胶囊与拖拽 ghost 共用一份渲染。
+ *  独立订阅自己的运行状态（切走后状态不丢）；苹果式设计：状态全收拢到头像图标
+ *  （黑白色系，仅语义色保留琥珀/绿点），胶囊本体与标题完全不动 */
+function TabPill({
+	session,
+	isActive,
+	ghost = false,
+	hidden = false,
+	buttonProps,
+}: {
+	session: SessionMeta;
+	isActive: boolean;
+	/** DragOverlay ghost：拾起视觉，无交互 */
+	ghost?: boolean;
+	/** 真实胶囊正被 ghost 接管：隐藏本体但保留布局槽位（邻居让位计算依赖它） */
+	hidden?: boolean;
+	buttonProps?: ComponentProps<"button">;
+}) {
 	const t = useT();
-	const switchSession = useSessionsStore((s) => s.switchSession);
 	const closeSession = useSessionsStore((s) => s.closeSession);
-	const setView = useUiStore((s) => s.setView);
 	// selector 返回字符串原始值，引用稳定不触发多余渲染
 	const status = useTranscriptStore((s): TabStatus => {
 		const entry = s.bySession[session.sessionId];
@@ -27,7 +78,6 @@ function SessionTab({ session, isActive }: { session: SessionMeta; isActive: boo
 	});
 	// 图标字母 = 项目名（cwd 最后一段）首字母，与会话标题无关
 	const letter = session.cwd.split("/").filter(Boolean).pop()?.[0] ?? "P";
-	// 苹果式设计：状态全部收拢到头像图标（黑白色系，仅语义色保留琥珀/绿点），胶囊本体与标题完全不动
 	const avatarClass =
 		status === "attention"
 			? "bg-amber-500"
@@ -39,13 +89,12 @@ function SessionTab({ session, isActive }: { session: SessionMeta; isActive: boo
 	return (
 		<button
 			type="button"
-			className={`no-drag group relative flex w-52 shrink-0 cursor-pointer items-center gap-2 rounded-lg px-2.5 py-1.5 text-sm transition-colors ${
+			{...buttonProps}
+			style={{ touchAction: "none", ...(hidden ? { opacity: 0 } : null) }}
+			className={`no-drag tab-pill group relative flex w-52 cursor-pointer items-center gap-2 rounded-lg px-2.5 py-1.5 text-sm ${
 				isActive ? "bg-border/80 text-ink" : "text-ink-dim hover:bg-hover hover:text-ink"
-			}`}
-			onClick={() => {
-				switchSession(session.sessionId);
-				setView("chat");
-			}}
+			} ${ghost ? "tab-dragging" : ""}`}
+			onClick={ghost ? undefined : buttonProps?.onClick}
 		>
 			<span
 				className={`relative flex h-4 w-4 shrink-0 items-center justify-center rounded text-[10px] font-semibold text-on-ink ${avatarClass}`}
@@ -59,31 +108,84 @@ function SessionTab({ session, isActive }: { session: SessionMeta; isActive: boo
 				<span className="block truncate pr-6 text-left">
 					{session.name ?? session.cwd.split("/").filter(Boolean).pop() ?? t("tabbar.untitled")}
 				</span>
-				<span
-					className="invisible absolute right-0 top-1/2 -translate-y-1/2 p-1 text-ink-dim opacity-0 transition-opacity hover:text-ink group-hover:visible group-hover:opacity-100"
-					aria-hidden="true"
-					onClick={(e) => {
-						e.stopPropagation();
-						void closeSession(session.sessionId);
-					}}
-				>
-					<CloseIcon />
-				</span>
+				{!ghost && (
+					<span
+						className="invisible absolute right-0 top-1/2 -translate-y-1/2 p-1 text-ink-dim opacity-0 transition-opacity hover:text-ink group-hover:visible group-hover:opacity-100"
+						aria-hidden="true"
+						onClick={(e) => {
+							e.stopPropagation();
+							void closeSession(session.sessionId);
+						}}
+					>
+						<CloseIcon />
+					</span>
+				)}
 			</span>
 		</button>
 	);
 }
 
-/** 顶栏：macOS hiddenInset 红绿灯左侧，会话 tab 从右排开 */
+/** 单个会话 tab：几何层（useSortable 的 transform/transition）在 wrapper div 上按 dnd-kit 协议
+ *  原样应用——transition 含 "none" 帧时绝不能覆盖成动画，那是 FLIP 布点帧（覆盖会造成落位回闪）；
+ *  拖拽本体隐藏、由 DragOverlay 的 ghost 跟随指针（见 DRAG_MODIFIERS 注释） */
+function SessionTab({ session, isActive }: { session: SessionMeta; isActive: boolean }) {
+	const switchSession = useSessionsStore((s) => s.switchSession);
+	const setView = useUiStore((s) => s.setView);
+	const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
+		id: session.sessionId,
+		// 自定义让位/落位节奏；reduced-motion 传 null = dnd-kit 不再给出过渡串
+		transition: prefersReducedMotion() ? null : { duration: 220, easing: SORT_EASE },
+	});
+	return (
+		<div
+			ref={setNodeRef}
+			className="shrink-0"
+			style={{
+				transform: transform ? `translate3d(${transform.x}px, ${transform.y}px, 0)` : undefined,
+				transition: transition || undefined,
+			}}
+		>
+			<TabPill
+				session={session}
+				isActive={isActive}
+				hidden={isDragging}
+				buttonProps={{
+					...attributes,
+					...listeners,
+					onClick: () => {
+						switchSession(session.sessionId);
+						setView("chat");
+					},
+				}}
+			/>
+		</div>
+	);
+}
+
+/** 顶栏：macOS hiddenInset 红绿灯左侧，会话 tab 从右排开，可拖拽排序（浏览器标签式） */
 export function SessionTabBar() {
 	const t = useT();
 	const sessions = useSessionsStore((s) => s.sessions);
 	const activeSessionId = useSessionsStore((s) => s.activeSessionId);
 	const createDraftSession = useSessionsStore((s) => s.createDraftSession);
+	const reorderSessions = useSessionsStore((s) => s.reorderSessions);
 	const cwd = useSessionsStore((s) => s.cwd);
 	const view = useUiStore((s) => s.view);
 	const setView = useUiStore((s) => s.setView);
 	const scrollerRef = useRef<HTMLDivElement>(null);
+	const [activeId, setActiveId] = useState<string | null>(null);
+	const activeSession = sessions.find((s) => s.sessionId === activeId);
+	// 拖拽期间：顶栏整体退出窗口拖拽区（胶囊间隙本是 drag-region，指针扫过会被 macOS 当拖窗口吞事件）
+	const dragging = activeId !== null;
+	// 5px 激活距离：原地点击/关胶囊不触发拖拽；键盘传感器支持 Space 抬起 + 左右键移动
+	const sensors = useSensors(
+		useSensor(PointerSensor, { activationConstraint: { distance: 5 } }),
+		useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates }),
+	);
+	const endDrag = () => {
+		setActiveId(null);
+		setDraggingCursor(false);
+	};
 
 	// 正在查看的会话：完成未读标记立即清除（覆盖切 tab 与 projects ↔ chat 视图切换）
 	useEffect(() => {
@@ -109,7 +211,9 @@ export function SessionTabBar() {
 	}, []);
 
 	return (
-		<div className="drag-region flex h-12 shrink-0 items-center gap-1 border-b border-border bg-canvas pl-20 pr-3">
+		<div
+			className={`${dragging ? "" : "drag-region"} flex h-12 shrink-0 items-center gap-1 border-b border-border bg-canvas pl-20 pr-3`}
+		>
 			<button
 				type="button"
 				className={`no-drag shrink-0 rounded-lg p-1.5 transition-colors ${
@@ -124,13 +228,41 @@ export function SessionTabBar() {
 				ref={scrollerRef}
 				className="flex min-w-0 flex-1 items-center gap-1 overflow-x-scroll [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
 			>
-				{sessions.map((session) => (
-					<SessionTab
-						key={session.sessionId}
-						session={session}
-						isActive={session.sessionId === activeSessionId}
-					/>
-				))}
+				<DndContext
+					sensors={sensors}
+					collisionDetection={closestCenter}
+					onDragStart={({ active }) => {
+						setActiveId(String(active.id));
+						setDraggingCursor(true);
+					}}
+					onDragEnd={({ active, over }: DragEndEvent) => {
+						endDrag();
+						if (over && active.id !== over.id) {
+							reorderSessions(String(active.id), String(over.id));
+						}
+					}}
+					onDragCancel={endDrag}
+				>
+					<SortableContext items={sessions.map((s) => s.sessionId)} strategy={horizontalListSortingStrategy}>
+						{sessions.map((session) => (
+							<SessionTab
+								key={session.sessionId}
+								session={session}
+								isActive={session.sessionId === activeSessionId}
+							/>
+						))}
+					</SortableContext>
+					{/* 拖拽 ghost：fixed 定位（不参与滚动区域 → 不会撑大 scrollWidth），
+					    落位时 fade 回槽位，真实胶囊同时 fade in（.tab-pill 的 opacity 过渡） */}
+					<DragOverlay
+						modifiers={DRAG_MODIFIERS}
+						dropAnimation={prefersReducedMotion() ? null : DROP_ANIMATION}
+					>
+						{activeSession ? (
+							<TabPill session={activeSession} isActive={activeSession.sessionId === activeSessionId} ghost />
+						) : null}
+					</DragOverlay>
+				</DndContext>
 			</div>
 			<UpdateButton />
 			{view !== "projects" && (

--- a/packages/desktop/src/renderer/src/stores/sessions.test.ts
+++ b/packages/desktop/src/renderer/src/stores/sessions.test.ts
@@ -176,6 +176,51 @@ describe("switchSession", () => {
 	});
 });
 
+describe("reorderSessions（拖拽排序）", () => {
+	const draftMeta = (name: string): SessionMeta => ({
+		...realMeta(name, "/p"),
+		sessionId: `${DRAFT_SESSION_PREFIX}x`,
+		sessionFile: undefined,
+	});
+
+	it("向后拖：a 跨过 draft 到末尾，并按新视觉序落盘", () => {
+		useSessionsStore.setState({
+			sessions: [realMeta("a", "/p"), draftMeta("dx"), realMeta("b", "/p")],
+			cwd: "/p",
+		});
+		useSessionsStore.getState().reorderSessions("a", "b");
+		expect(useSessionsStore.getState().sessions.map((s) => s.sessionId)).toEqual([
+			`${DRAFT_SESSION_PREFIX}x`,
+			"b",
+			"a",
+		]);
+		// files 只含真实会话，顺序 = 去掉 draft 后的视觉序
+		expect(piMock.saveTabs).toHaveBeenCalledWith({
+			files: ["/tmp/b.jsonl", "/tmp/a.jsonl"],
+			activeFile: null,
+		});
+	});
+
+	it("向前拖：插入到目标原索引，中间项整体右移（arrayMove 语义，与落位视觉一致）", () => {
+		useSessionsStore.setState({ sessions: [realMeta("a", "/p"), draftMeta("dx"), realMeta("b", "/p")] });
+		useSessionsStore.getState().reorderSessions("b", "a");
+		expect(useSessionsStore.getState().sessions.map((s) => s.sessionId)).toEqual([
+			"b",
+			"a",
+			`${DRAFT_SESSION_PREFIX}x`,
+		]);
+	});
+
+	it("原地/未知 id 不变序也不落盘", () => {
+		useSessionsStore.setState({ sessions: [realMeta("a", "/p"), realMeta("b", "/p")] });
+		useSessionsStore.getState().reorderSessions("a", "a");
+		useSessionsStore.getState().reorderSessions("nope", "b");
+		useSessionsStore.getState().reorderSessions("a", "nope");
+		expect(useSessionsStore.getState().sessions.map((s) => s.sessionId)).toEqual(["a", "b"]);
+		expect(piMock.saveTabs).not.toHaveBeenCalled();
+	});
+});
+
 describe("模型/思考级别", () => {
 	it("draft 下切换模型：只更新全局默认与 draft 条目，不调后端 setModel", async () => {
 		useSessionsStore.getState().createDraftSession("/proj/a");

--- a/packages/desktop/src/renderer/src/stores/sessions.ts
+++ b/packages/desktop/src/renderer/src/stores/sessions.ts
@@ -40,6 +40,8 @@ interface SessionsStore {
 	/** 设置新会话的目标项目目录；活跃 tab 是 draft 时同步更新其条目（切 tab 往返不丢选择） */
 	setDraftCwd: (cwd: string) => void;
 	switchSession: (sessionId: string) => void;
+	/** 拖拽排序顶栏胶囊：调整 sessions 数组顺序并落盘（tabs.json 的 files 本就保序，重启按新序恢复） */
+	reorderSessions: (fromId: string, toId: string) => void;
 	closeSession: (sessionId: string) => Promise<void>;
 	openFromHistory: (filePath: string) => Promise<void>;
 	/** 在指定 assistant 消息处分叉：新会话以新 tab 打开并切换过去（原会话保留原样） */
@@ -149,6 +151,20 @@ export const useSessionsStore = create<SessionsStore>((set, get) => ({
 		set((state) => ({
 			sessions: state.sessions.map((s) => (s.sessionId === sessionId ? { ...s, name } : s)),
 		})),
+
+	reorderSessions: (fromId, toId) => {
+		const { sessions } = get();
+		const from = sessions.findIndex((s) => s.sessionId === fromId);
+		const to = sessions.findIndex((s) => s.sessionId === toId);
+		if (from < 0 || to < 0 || from === to) return;
+		const next = [...sessions];
+		const [moved] = next.splice(from, 1);
+		if (!moved) return;
+		next.splice(to, 0, moved);
+		set({ sessions: next });
+		// draft 无 sessionFile 会被过滤，落盘的是真实会话的新视觉顺序
+		persistTabs(get());
+	},
 
 	closeSession: async (sessionId) => {
 		const isDraft = isDraftSessionId(sessionId);

--- a/packages/desktop/src/renderer/src/styles/globals.css
+++ b/packages/desktop/src/renderer/src/styles/globals.css
@@ -280,6 +280,37 @@
 	}
 }
 
+/* 会话胶囊拖拽排序：tab-pill 是内层视觉层（拾起 scale + 上浮 + 阴影，160ms 独立过渡；
+   opacity 同表：拖拽时本体淡出交由 DragOverlay ghost，落位时淡入，与 ghost fade 交叉）。
+   几何层的 translate/让位/FLIP 由 dnd-kit 内联 style 控制（见 SessionTabBar），两层互不干扰；
+   全程只动 transform/box-shadow/opacity，合成器友好 */
+.tab-pill {
+	transition:
+		transform 160ms cubic-bezier(0.2, 0, 0, 1),
+		box-shadow 160ms cubic-bezier(0.2, 0, 0, 1),
+		opacity 160ms ease;
+}
+.tab-dragging {
+	transform: scale(1.045) translateY(-1px);
+	box-shadow:
+		0 6px 18px rgb(0 0 0 / 0.18),
+		0 0 0 1px rgb(0 0 0 / 0.05);
+}
+/* 拖拽期间指针常在胶囊间隙上，cursor 挂根元素统一接管。
+   不用 !important：Tailwind 工具类在 @layer utilities，未分层规则天然优先 */
+.tab-dragging-cursor,
+.tab-dragging-cursor * {
+	cursor: grabbing;
+}
+@media (prefers-reduced-motion: reduce) {
+	.tab-pill {
+		transition: none;
+	}
+	.tab-dragging {
+		transform: none;
+	}
+}
+
 html,
 body,
 #root {


### PR DESCRIPTION
标题：
feat: 顶栏会话胶囊拖拽排序
正文：
## Summary

顶栏会话胶囊支持浏览器标签式拖拽排序，排序结果持久化到 tabs.json。

## Changes (1 commit)

- **@dnd-kit core+sortable+modifiers**：拖动 5px 拾起、邻居让位、落位 FLIP
- 拖拽视觉走 DragOverlay ghost（fixed 定位）：流内 transform 会撑大滚动容器 scrollWidth → 右向无限滚动，ghost 不参与滚动区域根治
- 轴锁定 restrictToHorizontalAxis + restrictToParentElement 挂 overlay：垂直不动、水平钳在 tab 条内；否则垂直位移会让 over 在相邻项间翻转 = 邻居让位抖动
- transition 严格按 dnd-kit 协议应用（自定义节奏经 useSortable 参数传入）：返回 "none" 布点帧被覆盖成动画会导致落位回闪
- 拾起视觉（scale+上浮+阴影）与几何 translate 分层，互不干扰；拖拽期间顶栏退出 drag-region（间隙吞指针）；reduced-motion 全关
- **sessions store 新增 reorderSessions**：arrayMove + persistTabs（tabs.json files 本就保序，重启按新序恢复；draft 只参与内存序）

## Test plan

- 拖拽排序后重启应用顺序保持
- 横向拖拽不越出 tab 条边界，无右向无限滚动
- reduced-motion 用户拖拽无动画