### PR TITLE
fix: 打包态 UI 插件构建失败（spawn ENOTDIR）+ 内置插件改为导出用户目录 (0.4.1)

### DIFF
--- a/packages/desktop/electron-builder.yml
+++ b/packages/desktop/electron-builder.yml
@@ -8,6 +8,10 @@ files:
   - "!node_modules/@percho"
 asarUnpack:
   - "**/*.node"
+  # UI 插件运行时构建：esbuild 要 spawn 平台二进制，asar 内无法 exec（spawn ENOTDIR）；
+  # unpack 后 Electron child_process 自动把 app.asar 路径重写为 app.asar.unpacked
+  - "**/node_modules/esbuild/**"
+  - "**/node_modules/@esbuild/**"
 # pi SDK 包资源镜像：docs/examples/README 不进 asar，agent 的 read/bash 工具都能直接访问。
 # main 进程经 PI_PACKAGE_DIR 指到这里（export-html/themes/package.json 同根解析，必须一起带）。
 extraResources:

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@percho/desktop",
-	"version": "0.4.0",
+	"version": "0.4.1",
 	"private": true,
 	"description": "Desktop GUI for the Pi coding agent",
 	"author": "Jaxton07",

--- a/packages/desktop/resources/ui-plugins/SPEC.md
+++ b/packages/desktop/resources/ui-plugins/SPEC.md
@@ -187,6 +187,7 @@ z 序：背景 0 < 内容 10 < overlay 20 < 设置弹窗 40 < 信任弹窗/全�
 - 同角多贡献纵向堆叠，顺序 = 启用先后（先启用的在上）；
 - `settings.panel` 贡献渲染为设置弹窗的独立分类（分类 id `plugin:<name>:<cid>`，标题 = `title`），随插件启停自动增删；
 - 排查：贡献根元素外层的宿主容器挂 `data-plugin="<name>"` 属性（插件无需自己做）；
+- **内置插件**：`resources/ui-plugins/builtin/` 随包分发，应用首次启动/升级时导出到用户插件目录（与用户插件同一条扫描/构建/热重载路径，面板带「内置」badge、启用免二次确认）。**直接改内置副本会在下次升级被覆盖——魔改请把目录改名另存**（`plugin.json` 的 `name` 同步改）；手动删除的目录本版本内不会回来，下次升级重新导出；
 - 新 hooks（`percho-ui.d.ts` 已声明）：`useContextUsage(sessionId)` 返回 `{ tokens, contextWindow, percent }`（事件驱动刷新，token 仪表盘用）；`useLanguage()` 返回 `"zh" | "en"`（插件自有文案跟随中英）。
 
 ### 10.4 示例

--- a/packages/desktop/src/main/ui-plugins/build.test.ts
+++ b/packages/desktop/src/main/ui-plugins/build.test.ts
@@ -71,18 +71,6 @@ export function Card() { return <img src={iconUrl} alt="" />; }
 		expect(out).toContain(pngB64);
 	});
 
-	it("自定义 outDir：产物落到指定目录（内置插件 resources 只读 → userData 缓存路径）", async () => {
-		const dir = await makePlugin(`
-export function Card() { return <div className="x">hi</div>; }
-`);
-		const outDir = join(dir, "cache-dist");
-		const res = await buildPlugin(dir, "src/index.tsx", { outDir });
-		expect(res).toEqual({ ok: true });
-		await expect(readFile(join(outDir, "index.js"), "utf-8")).resolves.toContain("window.PerchoUI");
-		// 默认路径不出产物
-		await expect(readFile(join(dir, "dist/index.js"), "utf-8")).rejects.toThrow();
-	});
-
 	it("语法错误返回首条错误 text+location 单行字符串，不产出 dist", async () => {
 		const dir = await makePlugin(`
 export function Card() { return <div>未闭合

--- a/packages/desktop/src/main/ui-plugins/build.ts
+++ b/packages/desktop/src/main/ui-plugins/build.ts
@@ -1,6 +1,27 @@
+import { existsSync } from "node:fs";
 import { join } from "node:path";
 import type { Plugin } from "esbuild";
-import { build } from "esbuild";
+
+/**
+ * 懒加载 esbuild + 打包态二进制路径修正（两件事必须一起做）：
+ * - 打包态 esbuild 平台二进制在 app.asar 内无法 exec（spawn ENOTDIR），需指向 asarUnpack 镜像出的真实文件；
+ * - esbuild 在**模块求值时**一次性缓存 ESBUILD_BINARY_PATH（main.js 顶层），
+ *   而 ESM import 提升会让静态 import 先于任何模块体执行 → 必须 import() 前动态设 env。
+ * dev/测试态 unpacked 路径不存在 → 不设环境变量，esbuild 默认按包布局解析。
+ */
+let esbuildPromise: Promise<typeof import("esbuild")> | null = null;
+function loadEsbuild(): Promise<typeof import("esbuild")> {
+	if (!esbuildPromise) {
+		const bin = process.platform === "win32" ? "esbuild.exe" : "esbuild";
+		const unpacked = join(
+			process.resourcesPath ?? "",
+			`app.asar.unpacked/node_modules/@esbuild/${process.platform}-${process.arch}/bin/${bin}`,
+		);
+		if (existsSync(unpacked)) process.env.ESBUILD_BINARY_PATH = unpacked;
+		esbuildPromise = import("esbuild");
+	}
+	return esbuildPromise;
+}
 
 /**
  * 宿主 API 暴露面（四个虚拟模块的 shim 重写目标 = window.PerchoUI）。
@@ -82,6 +103,7 @@ export async function buildPlugin(
 	// 产物目录：默认插件目录内 dist/；内置插件（resources 只读）由 manager 指定 userData 版本化缓存目录
 	const outDir = options?.outDir ?? join(pluginDir, "dist");
 	try {
+		const { build } = await loadEsbuild();
 		await build({
 			entryPoints: [join(pluginDir, mainEntry)],
 			bundle: true,

--- a/packages/desktop/src/main/ui-plugins/manager.ts
+++ b/packages/desktop/src/main/ui-plugins/manager.ts
@@ -37,14 +37,39 @@ function pluginsDir(): string {
 	return join(app.getPath("userData"), "ui-plugins");
 }
 
-/** 内置插件源码目录（随包分发，packaged 态在 .app 内只读）；userData 同名插件遮蔽内置版 */
+/** 内置插件源码目录（随包分发，packaged 态在 .app 内只读）；init 时导出到用户插件目录 */
 function builtinPluginsDir(): string {
 	return join(uiPluginsResourcesDir(), "builtin");
 }
 
-/** 内置插件产物缓存根：按应用版本分层（升级自动重建；dev 期靠 mtime 检查迭代） */
-function builtinDistRoot(): string {
-	return join(app.getPath("userData"), "ui-plugins-builtin", app.getVersion());
+/** 内置插件导出戳：记录上次导出时的应用版本（点开头过不了 NAME_RE，不会被当插件扫描） */
+function builtinSeedStampPath(): string {
+	return join(pluginsDir(), ".builtin-seed.json");
+}
+
+/**
+ * 导出内置插件到用户插件目录——之后与用户插件走**同一条**扫描/构建/热重载/读码路径，无特殊分支。
+ * 策略：仅首次安装 / 应用版本变化时整树刷新（copyTree 内容一致自动跳过）；同版本重启直接返回零开销；
+ * dev 态每次跑 copyTree（一致跳过 ≈ 零开销，源码迭代即时生效）。
+ * 边界语义：手动删除某内置目录 → 本版本内不再回来（尊重删除），下次升级重新导出；
+ * 直接改内置副本 → 升级时被覆盖（注释与 SPEC 都写明：魔改请把目录改名另存，面板「打开目录」可达）。
+ */
+async function seedBuiltinPlugins(): Promise<void> {
+	const stampPath = builtinSeedStampPath();
+	const version = app.getVersion();
+	const stamp = await readFile(stampPath, "utf-8")
+		.then((s) => JSON.parse(s) as { version?: string })
+		.catch(() => null);
+	if (app.isPackaged && stamp?.version === version) return;
+	const src = builtinPluginsDir();
+	const entries = await readdir(src, { withFileTypes: true }).catch(() => []);
+	for (const entry of entries) {
+		if (!entry.isDirectory() || !NAME_RE.test(entry.name)) continue;
+		await copyTree(join(src, entry.name), join(pluginsDir(), entry.name));
+	}
+	await writeFile(stampPath, JSON.stringify({ version }), "utf-8").catch((err) =>
+		log.error("builtin seed stamp failed", err),
+	);
 }
 
 /** 随包资源目录：dev 态 = packages/desktop/resources/ui-plugins；packaged 态 = resources/ui-plugins（extraResources 镜像） */
@@ -236,31 +261,29 @@ export class UiPluginManager {
 	private infos = new Map<string, UiPluginInfo>();
 	/** name → 插件目录绝对路径（白名单：readCode/openDir 只接受扫描到的合法名） */
 	private dirNames = new Map<string, string>();
-	/** 内置插件名集合（scanAll 重建；产物路径走 userData 缓存而非插件目录） */
+	/** 随包内置插件名集合（init 时导出到用户目录；此处仅用于合成 builtin 标志 → 面板 badge/启用免确认） */
 	private builtinNames = new Set<string>();
 	/** 持久化配置缓存（updateConfig 后刷新；scanAll 时叠加） */
 	private config: UiPluginsConfig = defaultUiPluginsConfig();
-	/** 热重载 watcher（startWatcher 启动；will-quit 时关闭；[0]=用户目录 [1]=内置目录） */
+	/** 热重载 watcher（startWatcher 启动；will-quit 时关闭） */
 	private watchers: FSWatcher[] = [];
 	/** 插件名 → 防抖重建定时器（连续保存只重建一次） */
 	private rebuildTimers = new Map<string, NodeJS.Timeout>();
 
-	/** 确保插件根目录存在、分发规范文档（SPEC/percho-ui.d.ts/symlink）并加载配置 + 首次扫描 */
+	/** 确保插件根目录存在、分发规范文档与内置插件、加载配置 + 首次扫描 */
 	async init(): Promise<void> {
 		await mkdir(pluginsDir(), { recursive: true });
+		// 0.4.0 内置插件版本化缓存目录的遗留（seed 方案后不再需要，静默清掉）
+		await rm(join(app.getPath("userData"), "ui-plugins-builtin"), { recursive: true, force: true }).catch(
+			() => {},
+		);
 		await seedDocs();
+		await seedBuiltinPlugins();
 		await this.scanAll();
 	}
 
-	/** 插件产物目录：用户插件 = 插件目录内 dist/；内置插件 = userData 版本化缓存（resources 只读写不得） */
-	private distDirOf(name: string): string | null {
-		const src = this.dirNames.get(name);
-		if (!src) return null;
-		return this.builtinNames.has(name) ? join(builtinDistRoot(), name, "dist") : join(src, "dist");
-	}
-
-	/** 合成单个插件的 UiPluginInfo（用户/内置两路扫描共用） */
-	private async scanOne(name: string, srcDir: string, builtin: boolean): Promise<UiPluginInfo> {
+	/** 合成单个插件的 UiPluginInfo（统一从用户插件目录扫描；builtin 标志来自随包名单） */
+	private async scanOne(name: string, srcDir: string): Promise<UiPluginInfo> {
 		const manifest = await readManifest(srcDir);
 		const invalidReason = validateManifest(name, manifest ?? {});
 		const prev = this.infos.get(name);
@@ -276,18 +299,22 @@ export class UiPluginManager {
 			trusted: this.config.plugins[name]?.trusted ?? false,
 			invalidReason: invalidReason ?? undefined,
 			buildError: prev?.buildError,
-			built: existsSync(join(this.distDirOf(name) ?? "", "index.js")),
-			builtin: builtin || undefined, // 用户插件不落字段（保持载荷干净）
+			built: existsSync(join(srcDir, "dist/index.js")),
+			builtin: this.builtinNames.has(name) || undefined, // 用户插件不落字段（保持载荷干净）
 		};
 	}
 
-	/** 扫描 userData/ui-plugins/ + resources builtin/ 每个子目录：校验 manifest 并合成 UiPluginInfo（叠加 config/产物状态） */
+	/** 扫描 userData/ui-plugins/ 每个子目录：校验 manifest 并合成 UiPluginInfo（叠加 config/产物状态） */
 	async scanAll(): Promise<UiPluginInfo[]> {
 		this.config = await loadUiPluginsConfig();
+		// 随包内置名单（每次扫描现取，目录静态几乎零开销）
+		const builtinEntries = await readdir(builtinPluginsDir(), { withFileTypes: true }).catch(() => []);
+		this.builtinNames = new Set(
+			builtinEntries.filter((e) => e.isDirectory() && NAME_RE.test(e.name)).map((e) => e.name),
+		);
 		const dir = pluginsDir();
 		const out: UiPluginInfo[] = [];
 		const seen = new Set<string>();
-		this.builtinNames.clear();
 		const entries = await readdir(dir, { withFileTypes: true }).catch((err) => {
 			log.error("scanAll readdir failed", err);
 			return [];
@@ -298,23 +325,8 @@ export class UiPluginManager {
 			if (!NAME_RE.test(name)) continue; // 目录名非法直接跳过（不占白名单）
 			seen.add(name);
 			this.dirNames.set(name, join(dir, name));
-			const info = await this.scanOne(name, join(dir, name), false);
+			const info = await this.scanOne(name, join(dir, name));
 			this.infos.set(name, info);
-			out.push(info);
-		}
-		// 内置插件：随包分发；userData 同名遮蔽（用户 fork 魔改优先）
-		const builtinEntries = await readdir(builtinPluginsDir(), { withFileTypes: true }).catch(() => []);
-		for (const entry of builtinEntries) {
-			if (!entry.isDirectory() || !NAME_RE.test(entry.name)) continue;
-			if (seen.has(entry.name)) {
-				log.warn(`内置插件被 userData 同名插件遮蔽: ${entry.name}`);
-				continue;
-			}
-			seen.add(entry.name);
-			this.dirNames.set(entry.name, join(builtinPluginsDir(), entry.name));
-			this.builtinNames.add(entry.name);
-			const info = await this.scanOne(entry.name, join(builtinPluginsDir(), entry.name), true);
-			this.infos.set(entry.name, info);
 			out.push(info);
 		}
 		// 清理幽灵条目：目录已删除/改名的插件从两个 Map 移除（否则面板显示已删除插件直到重启）
@@ -346,9 +358,8 @@ export class UiPluginManager {
 		if (!info || info.invalidReason) return false;
 		const pluginDir = this.dirNames.get(name);
 		const manifest = await readManifest(pluginDir ?? "");
-		const distDir = this.distDirOf(name);
-		if (!pluginDir || !manifest || typeof manifest.main !== "string" || !distDir) return false;
-		const dist = join(distDir, "index.js");
+		if (!pluginDir || !manifest || typeof manifest.main !== "string") return false;
+		const dist = join(pluginDir, "dist/index.js");
 		try {
 			let needsBuild = force || !existsSync(dist);
 			if (!needsBuild) {
@@ -357,7 +368,7 @@ export class UiPluginManager {
 				needsBuild = srcMtime === null || !distStat || srcMtime > distStat.mtimeMs;
 			}
 			if (needsBuild) {
-				const res = await buildPlugin(pluginDir, manifest.main, { outDir: distDir });
+				const res = await buildPlugin(pluginDir, manifest.main);
 				if (res.ok) {
 					this.infos.set(name, { ...info, buildError: undefined, built: true });
 				} else {
@@ -380,19 +391,18 @@ export class UiPluginManager {
 		const info = this.infos.get(name);
 		if (!info || info.invalidReason) return { error: `未知插件 ${name}` };
 		const pluginDir = this.dirNames.get(name);
-		const distDir = this.distDirOf(name);
-		if (!pluginDir || !distDir) return { error: `未知插件 ${name}` };
+		if (!pluginDir) return { error: `未知插件 ${name}` };
 		const ok = await this.ensureBuilt(name);
 		if (!ok) {
 			// 构建失败：旧产物存在则继续生效（spec §6，不清 dist）；buildError 已进 list 由面板展示
-			if (!existsSync(join(distDir, "index.js"))) {
+			if (!existsSync(join(pluginDir, "dist/index.js"))) {
 				return { error: this.infos.get(name)?.buildError ?? `构建失败：${name}` };
 			}
 		}
 		try {
 			const [manifest, code] = await Promise.all([
 				readManifest(pluginDir),
-				readFile(join(distDir, "index.js"), "utf-8"),
+				readFile(join(pluginDir, "dist/index.js"), "utf-8"),
 			]);
 			if (!manifest || validateManifest(name, manifest)) return { error: "manifest 校验失败" };
 			// 未知 region 条目已被过滤（与 scanAll 合成 info 同源），registry 只注册已知区域
@@ -418,27 +428,27 @@ export class UiPluginManager {
 	}
 
 	/**
-	 * 启动热重载 watcher：监听用户插件目录 + 内置插件目录（recursive），变更落在某插件的 src/ 或 plugin.json
+	 * 启动热重载 watcher：监听插件目录（recursive），变更落在某插件的 src/ 或 plugin.json
 	 * → 300ms 防抖后重新扫描+构建（无论成败）→ 回调通知（推 { kind: "changed", name }）。
 	 * dist/ 下的构建产物事件忽略（否则构建自身会触发重建死循环）；watch 失败只告警不致命。
+	 * （内置插件已导出到本目录，天然被覆盖——无需第二路 watcher）
 	 */
 	startWatcher(onChange: (name: string) => void): void {
 		if (this.watchers.length > 0) return;
-		const handler = (_event: string, filename: string | null) => {
-			if (typeof filename !== "string") return;
-			const rel = filename.split(/[\\/]/);
-			const name = rel[0];
-			if (!name || !NAME_RE.test(name)) return;
-			const rest = rel.slice(1);
-			if (rest.length === 0 || rest[0] === "dist") return; // 目录事件/构建产物忽略
-			this.scheduleRebuild(name, onChange);
-		};
-		for (const dir of [pluginsDir(), builtinPluginsDir()]) {
-			try {
-				this.watchers.push(watch(dir, { recursive: true }, handler));
-			} catch (err) {
-				log.error("fs.watch failed（该目录热重载不可用，手动重建不受影响）", dir, err);
-			}
+		try {
+			this.watchers.push(
+				watch(pluginsDir(), { recursive: true }, (_event, filename) => {
+					if (typeof filename !== "string") return;
+					const rel = filename.split(/[\\/]/);
+					const name = rel[0];
+					if (!name || !NAME_RE.test(name)) return;
+					const rest = rel.slice(1);
+					if (rest.length === 0 || rest[0] === "dist") return; // 目录事件/构建产物忽略
+					this.scheduleRebuild(name, onChange);
+				}),
+			);
+		} catch (err) {
+			log.error("fs.watch failed（热重载不可用，手动重建不受影响）", err);
 		}
 	}
 


### PR DESCRIPTION
## 问题

0.4.0 打包版中所有 UI 插件（含内置鲸鱼娘）构建失败：`Error: spawn ENOTDIR`。esbuild 运行时要 spawn 平台二进制，但二进制在 app.asar 归档内部——不是真实文件系统路径。dev 态无此问题，插件链路此前未在打包态验证过。

## 修复

1. **`asarUnpack` 加 esbuild**：`**/node_modules/esbuild/**` + `**/node_modules/@esbuild/** `。实测确认 Electron child_process **不会**自动把 app.asar 重写为 app.asar.unpacked
2. **build.ts 懒加载 esbuild**：esbuild 在模块求值时一次性缓存 `ESBUILD_BINARY_PATH`（main.js 顶层 var），ESM import 提升使静态 import 先于模块体执行——改为 `loadEsbuild()` 先设 env 再 `import()`。dev 态 unpacked 路径不存在则不设，走默认包布局解析

## 简化（内置插件机制重做）

按「内置插件导出到用户插件目录」的思路：**init 时把 resources builtin/ 整树导出到 `userData/ui-plugins/`**，之后与用户插件共用同一条扫描/构建/热重载/读码路径，拆除版本化产物缓存（distDirOf）与双目录 watcher：

- 版本戳 `.builtin-seed.json`：仅安装/升级时刷新（copyTree 内容一致自动跳过），同版本重启零 IO
- 手动删除的内置目录本版本内不回来（尊重删除），下次升级重新导出
- 直接改内置副本升级时被覆盖（SPEC 注明：魔改请把目录改名另存）
- init 顺带清理 0.4.0 遗留的 `ui-plugins-builtin/` 缓存目录

## 验证

- typecheck / lint / vitest 全绿
- **打包态实测**：`electron-builder --dir` 产物启动 → rebuild 成功 → 启用后鲸鱼娘正常渲染（0.4.0 失败路径复现后验证修复）