### PR TITLE
fix: UI 插件总开关不覆盖 Region 贡献 (0.4.2)

### DIFF
--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@percho/desktop",
-	"version": "0.4.1",
+	"version": "0.4.2",
 	"private": true,
 	"description": "Desktop GUI for the Pi coding agent",
 	"author": "Jaxton07",

--- a/packages/desktop/src/renderer/src/components/settings/SettingsDialog.tsx
+++ b/packages/desktop/src/renderer/src/components/settings/SettingsDialog.tsx
@@ -6,6 +6,7 @@ import { EMPTY_CONTRIBUTIONS } from "../../plugins/RegionHost";
 import { type Contribution, useUiPluginRegistry } from "../../plugins/registry";
 import { UI_REGIONS } from "../../plugins/slots";
 import { type SettingsCategory, useSettingsStore } from "../../stores/settings";
+import { useUiPluginsStore } from "../../stores/ui-plugins";
 import { AboutPanel } from "./AboutPanel";
 import { AppearancePanel } from "./AppearancePanel";
 import { ExtensionsPanel } from "./ExtensionsPanel";
@@ -66,8 +67,10 @@ export function SettingsDialog() {
 	const setCategory = useSettingsStore((s) => s.setCategory);
 
 	// settings.panel 贡献：动态分类（插件停用/卸载即消失）；稳定引用（空用模块级 EMPTY）
-	const pluginCategories =
-		useUiPluginRegistry((s) => s.contributions[UI_REGIONS.SettingsPanel]) ?? EMPTY_CONTRIBUTIONS;
+	// 全局总开关关闭时隐藏插件分类（与 RegionHost 同一开关语义；当前正在看的分类回落 comingSoon 空态）
+	const masterOn = useUiPluginsStore((s) => s.config.enabled);
+	const registryCategories = useUiPluginRegistry((s) => s.contributions[UI_REGIONS.SettingsPanel]);
+	const pluginCategories = masterOn ? (registryCategories ?? EMPTY_CONTRIBUTIONS) : EMPTY_CONTRIBUTIONS;
 	// 贡献边界 key 带 loadNonce（与 RegionHost 一致）：热重载换新边界实例，settings.panel 贡献崩溃后可恢复
 	const pluginNonces = useUiPluginRegistry((s) => s.loadNonces);
 

--- a/packages/desktop/src/renderer/src/plugins/RegionHost.tsx
+++ b/packages/desktop/src/renderer/src/plugins/RegionHost.tsx
@@ -1,5 +1,6 @@
 import type { UiPluginAnchor } from "@percho/shared";
 import type { ComponentType } from "react";
+import { useUiPluginsStore } from "../stores/ui-plugins";
 import { PluginBoundary } from "./PluginBoundary";
 import { type Contribution, useUiPluginRegistry } from "./registry";
 import { type RegionName, UI_REGIONS } from "./slots";
@@ -41,7 +42,9 @@ export function RegionHost({ region }: { region: RegionName }) {
 	const list = useUiPluginRegistry((s) => s.contributions[region]) ?? EMPTY_CONTRIBUTIONS;
 	// 热重载换新边界实例（errored 归零），与 Slot 的 key 语义一致
 	const nonces = useUiPluginRegistry((s) => s.loadNonces);
-	if (list.length === 0) return null;
+	// 全局总开关：关 = 全部贡献立即停用（与 Slot 同一开关语义；registry 保留，开回即恢复）
+	const masterOn = useUiPluginsStore((s) => s.config.enabled);
+	if (!masterOn || list.length === 0) return null;
 
 	const renderContribution = (c: Contribution) => {
 		const Comp = c.component as ComponentType<Record<string, never>>;


### PR DESCRIPTION
## 问题

0.4.1 实踩：设置 → UI 插件关掉总开关后，桌宠（app.overlay 贡献）仍然挂在界面上。槽位替换（Slot.tsx）有 masterEnabled 门控会立即回退默认组件，但 **RegionHost 和 SettingsDialog 的插件分类直接读 registry，没接总开关**。

## 修复

- `RegionHost`：`config.enabled` 关 → 全部区域贡献立即不渲染（registry 保留，开回即恢复，与 Slot 同一开关语义）
- `SettingsDialog`：总开关关 → settings.panel 插件动态分类隐藏（正在看的分类回落 comingSoon 空态）

## 验证

- typecheck / lint / vitest 全绿
- dev CDP 实测：master off → 桌宠立即消失；master on → 恢复；per-plugin 启用状态按设计保留