### PR TITLE
fix(subagent): flatten tool params schema — 修复 DeepSeek 400 / 全 provider 兼容

### DIFF
--- a/packages/backend/src/pi-backend.ts
+++ b/packages/backend/src/pi-backend.ts
@@ -195,6 +195,7 @@ export class PiBackend {
 					getSubagentModel: (agentName) => this.modelPrefs.getSubagentModel(agentName),
 					gate,
 					traces: this.traces,
+					onEvent: (sessionId, event) => this.emitEvent(sessionId, event),
 				}),
 			);
 		}
@@ -345,9 +346,11 @@ export class PiBackend {
 			autoNameSession(session, event);
 			this.emitEvent(session.sessionId, event);
 		});
-		// 子代理产物目录下的会话文件 = 只读检视（spec §8.1：防能力静默漂移/递归绕过）
-		this.registry.add({ session, unsubscribe, cwd, readOnly: isSubagentSessionPath(filePath) || undefined });
-		await this.traces.start(session.sessionId, session.sessionManager.getSessionDir());
+		// 子代理产物目录下的会话文件 = 只读检视（spec §8.1：防能力静默漂移/递归绕过）。
+		// 其运行 trace 由 runner 管理，检视页不可写，故不另建 recorder（避免覆盖运行中的 recorder）。
+		const readOnly = isSubagentSessionPath(filePath);
+		this.registry.add({ session, unsubscribe, cwd, readOnly: readOnly || undefined });
+		if (!readOnly) await this.traces.start(session.sessionId, session.sessionManager.getSessionDir());
 		log.info("session opened", session.sessionId, { file: filePath });
 		return this.toMetaOrThrow(session.sessionId);
 	}

--- a/packages/backend/src/pi-backend.ts
+++ b/packages/backend/src/pi-backend.ts
@@ -41,6 +41,8 @@ import {
 	DEFAULT_VISION_BASE_URL,
 	DEFAULT_VISION_MODEL,
 	extractTodos,
+	formatSkillCommand,
+	parseExpandedSkillInvocation,
 	TODO_REMINDER_CUSTOM_TYPE,
 	TODO_TOOL_NAME,
 	type TodoItem,
@@ -683,7 +685,9 @@ export class PiBackend {
 		const target = sm.getEntry(targetId) as Extract<SessionEntry, { type: "message" }>;
 		const message = target.message as RawMessage;
 		// 文本/图片从目标 entry 提取（navigateTree 只返回 editorText，图片会丢）
-		const text = blockText(message.content);
+		const sourceText = blockText(message.content);
+		const invocation = parseExpandedSkillInvocation(sourceText);
+		const text = invocation ? formatSkillCommand(invocation) : sourceText;
 		const images = blockImages(message.content);
 		if (sm.getLeafId() === targetId) {
 			// 悬挂的用户消息（发出后无任何回复，entry 即当前 leaf）：navigateTree 视为 no-op，

--- a/packages/backend/src/session/messages.ts
+++ b/packages/backend/src/session/messages.ts
@@ -2,6 +2,7 @@ import type { SessionEntry, SessionManager } from "@earendil-works/pi-coding-age
 import {
 	extractSubagentRuns,
 	type ImageInput,
+	parseExpandedSkillInvocation,
 	type SessionMessage,
 	type SessionToolCall,
 } from "@percho/shared";
@@ -157,13 +158,16 @@ export function toSessionMessages(rawMessages: readonly unknown[]): SessionMessa
 	const toolById = new Map<string, SessionToolCall>();
 	for (const raw of rawMessages as RawMessage[]) {
 		if (raw.role === "user") {
+			const sourceText = blockText(raw.content);
+			const invocation = parseExpandedSkillInvocation(sourceText);
 			out.push({
 				role: "user",
-				text: blockText(raw.content),
+				text: invocation ? (invocation.args ?? "") : sourceText,
 				thinking: "",
 				tools: [],
 				images: blockImages(raw.content),
 				timestamp: raw.timestamp ?? Date.now(),
+				...(invocation ? { skill: { name: invocation.name, args: invocation.args }, sourceText } : {}),
 			});
 			continue;
 		}

--- a/packages/backend/src/tools/subagent/runner.ts
+++ b/packages/backend/src/tools/subagent/runner.ts
@@ -53,6 +53,8 @@ export interface RunSubagentDeps {
 	getSubagentModel: (agentName: string) => Promise<string | undefined>;
 	gate: PermissionGate;
 	traces: SessionTraces;
+	/** 把运行中子会话事件转发给宿主；未提供时只写 trace（供非桌面宿主使用）。 */
+	onEvent?: (sessionId: string, event: AgentSessionEvent) => void;
 }
 
 const EMPTY_USAGE: SubagentUsage = {
@@ -223,8 +225,6 @@ export async function runSubagent(deps: RunSubagentDeps, input: RunSubagentInput
 		usage: structuredClone(EMPTY_USAGE),
 		artifactPaths: { jsonlPath: session.sessionFile },
 	};
-	input.onProgress?.(result);
-
 	let settled = false;
 	let failure: string | undefined;
 	let unsubscribeEvents: (() => void) | undefined;
@@ -232,7 +232,8 @@ export async function runSubagent(deps: RunSubagentDeps, input: RunSubagentInput
 	// （正常结束 / 异常逃逸 / abort）都触发；agent_end 在 overflow 重试（willRetry）或异常时不算终结。
 	const endPromise = new Promise<void>((resolve) => {
 		unsubscribeEvents = session.subscribe((event: AgentSessionEvent) => {
-			void deps.traces.record(session.sessionId, event);
+			if (deps.onEvent) deps.onEvent(session.sessionId, event);
+			else deps.traces.record(session.sessionId, event);
 			if (event.type === "message_end") addUsage(result.usage, usageFromMessage(event.message));
 			if (event.type === "agent_settled") {
 				settled = true;
@@ -248,6 +249,8 @@ export async function runSubagent(deps: RunSubagentDeps, input: RunSubagentInput
 		else input.signal.addEventListener("abort", abort, { once: true });
 	}
 	try {
+		// sessionFile 已在创建时落盘；先通知父工具/UI，用户即可在首个模型事件前进入实时子会话。
+		input.onProgress?.(result);
 		await deps.traces.start(session.sessionId, session.sessionManager.getSessionDir());
 		// expandPromptTemplates: false——子会话无任何模板/命令，任务文本以 "/" 开头也不触发命令解析
 		await session.prompt(input.task, { expandPromptTemplates: false });

--- a/packages/backend/src/tools/subagent/tool.ts
+++ b/packages/backend/src/tools/subagent/tool.ts
@@ -21,13 +21,30 @@ const taskSchema = Type.Object({
 	cwd: Type.Optional(Type.String({ minLength: 1, description: "Optional working directory" })),
 });
 
-const subagentParams = Type.Union([
-	Type.Intersect([taskSchema, Type.Object({ confirmProjectAgents: Type.Optional(Type.Boolean()) })]),
-	Type.Object({
-		tasks: Type.Array(taskSchema, { minItems: 1, maxItems: MAX_TASKS }),
-		confirmProjectAgents: Type.Optional(Type.Boolean()),
-	}),
-]);
+/**
+ * 拍平为单一 object schema（导出供测试断言）。不能用 Type.Union/Intersect：
+ * - openai-completions 路径原样发送 schema，anyOf 顶层无 type:"object"，DeepSeek 直接 400；
+ * - anthropic 路径的 convertTools 只保留顶层 properties/required，anyOf 会被剥成空 object，
+ *   模型失去参数描述（kimi 断流/参数空洞的诱因）。
+ * single / parallel 的互斥约束因此下沉到 execute 运行时校验。
+ */
+export const subagentParams = Type.Object({
+	agent: Type.Optional(
+		Type.String({ minLength: 1, description: "Agent definition name, e.g. scout (single run)" }),
+	),
+	task: Type.Optional(
+		Type.String({ minLength: 1, description: "Self-contained task for the subagent (single run)" }),
+	),
+	cwd: Type.Optional(Type.String({ minLength: 1, description: "Optional working directory" })),
+	tasks: Type.Optional(
+		Type.Array(taskSchema, {
+			minItems: 1,
+			maxItems: MAX_TASKS,
+			description: `Parallel runs (up to ${MAX_TASKS} tasks); mutually exclusive with agent/task`,
+		}),
+	),
+	confirmProjectAgents: Type.Optional(Type.Boolean()),
+});
 
 export interface MakeSubagentToolDeps {
 	getModelRuntime: () => Promise<ModelRuntime>;
@@ -149,8 +166,20 @@ export function makeSubagentTool(deps: MakeSubagentToolDeps): ToolDefinition {
 		): Promise<AgentToolResult<SubagentDetails>> => {
 			void toolCallId;
 			const params = rawParams as Static<typeof subagentParams>;
-			const mode: SubagentDetails["mode"] = "tasks" in params ? "parallel" : "single";
-			const tasks = "tasks" in params ? params.tasks : [params];
+			// 原 Union 的互斥约束运行时兜底：tasks 非空 → parallel，否则 agent+task 必填
+			const parallelTasks = params.tasks?.length ? params.tasks : undefined;
+			let tasks: Array<Static<typeof taskSchema>>;
+			if (parallelTasks) {
+				tasks = parallelTasks;
+			} else {
+				if (!params.agent || !params.task) {
+					throw new Error(
+						'Missing "agent"/"task": pass { agent, task } for one run or { tasks: [...] } for parallel',
+					);
+				}
+				tasks = [{ agent: params.agent, task: params.task, ...(params.cwd ? { cwd: params.cwd } : {}) }];
+			}
+			const mode: SubagentDetails["mode"] = parallelTasks ? "parallel" : "single";
 			const shouldConfirm = params.confirmProjectAgents !== false;
 			const projectTrusted = ctx.isProjectTrusted();
 			const definitions = await Promise.all(

--- a/packages/backend/src/tools/subagent/tool.ts
+++ b/packages/backend/src/tools/subagent/tool.ts
@@ -1,4 +1,5 @@
 import type {
+	AgentSessionEvent,
 	AgentToolResult,
 	ExtensionContext,
 	ModelRuntime,
@@ -33,6 +34,8 @@ export interface MakeSubagentToolDeps {
 	getSubagentModel: (agentName: string) => Promise<string | undefined>;
 	gate: PermissionGate;
 	traces: SessionTraces;
+	/** 把运行中子会话事件转发给桌面会话订阅方。 */
+	onEvent?: (sessionId: string, event: AgentSessionEvent) => void;
 }
 
 interface SubagentDetails {

--- a/packages/backend/test/skill-invocation.test.ts
+++ b/packages/backend/test/skill-invocation.test.ts
@@ -1,0 +1,101 @@
+import type { Message } from "@earendil-works/pi-ai";
+import { SessionManager } from "@earendil-works/pi-coding-agent";
+import { formatSkillCommand, parseExpandedSkillInvocation, type SkillInvocation } from "@percho/shared";
+import { describe, expect, it } from "vitest";
+import { PiBackend } from "../src/pi-backend";
+import { toSessionMessages } from "../src/session/messages";
+import type { SessionRegistry } from "../src/session/registry";
+
+const canonicalSkill = (args?: string) =>
+	`<skill name="mindmap" location="/tmp/skills/mindmap/SKILL.md">\nReferences are relative to /tmp/skills/mindmap.\n\n# Mind map\n\nBody\n</skill>${args ? `\n\n${args}` : ""}`;
+
+describe("expanded skill invocation parser", () => {
+	it("parses the canonical producer format with no args, multiline args, and formats commands", () => {
+		const expected: SkillInvocation = {
+			name: "mindmap",
+			location: "/tmp/skills/mindmap/SKILL.md",
+			args: "first\nsecond",
+		};
+		expect(parseExpandedSkillInvocation(canonicalSkill("  first\nsecond  "))).toEqual(expected);
+		expect(parseExpandedSkillInvocation(canonicalSkill())).toEqual({
+			name: "mindmap",
+			location: "/tmp/skills/mindmap/SKILL.md",
+			args: undefined,
+		});
+		expect(formatSkillCommand(expected)).toBe("/skill:mindmap first\nsecond");
+		expect(formatSkillCommand({ name: "mindmap" })).toBe("/skill:mindmap");
+	});
+
+	it("rejects non-canonical and partial text, including the SDK helper's wider XML shape", () => {
+		for (const text of [
+			"ordinary text",
+			'<skill name="mindmap" location="/tmp/x">\nbody\n</skill>',
+			canonicalSkill().slice(0, -8),
+		]) {
+			expect(parseExpandedSkillInvocation(text)).toBeNull();
+		}
+	});
+});
+
+describe("skill invocation history projection", () => {
+	it("compacts canonical skill user messages while retaining source text for matching", () => {
+		const sourceText = canonicalSkill("topic\nwith details");
+		const messages = toSessionMessages([
+			{ role: "user", content: sourceText, timestamp: 1 },
+			{ role: "user", content: "ordinary text", timestamp: 2 },
+		]);
+		expect(messages[0]).toMatchObject({
+			role: "user",
+			text: "topic\nwith details",
+			skill: { name: "mindmap", args: "topic\nwith details" },
+			sourceText,
+		});
+		expect(messages[1]).toEqual({
+			role: "user",
+			text: "ordinary text",
+			thinking: "",
+			tools: [],
+			images: [],
+			timestamp: 2,
+		});
+	});
+
+	it("projects a no-argument skill as an empty text bubble", () => {
+		expect(toSessionMessages([{ role: "user", content: canonicalSkill(), timestamp: 1 }])[0]).toMatchObject({
+			role: "user",
+			text: "",
+			skill: { name: "mindmap", args: undefined },
+			sourceText: canonicalSkill(),
+		});
+	});
+});
+
+describe("PiBackend skill recall", () => {
+	it("returns a reusable command while resolving the persisted canonical text", async () => {
+		const sourceText = canonicalSkill("layout");
+		const sessionManager = SessionManager.inMemory();
+		const entryId = sessionManager.appendMessage({
+			role: "user",
+			content: sourceText,
+			timestamp: 1,
+		} satisfies Message);
+		const backend = new PiBackend({ projectTrust: false, permissionGates: false });
+		const registry = (backend as unknown as { registry: SessionRegistry }).registry;
+		registry.add({
+			session: {
+				sessionId: "s1",
+				isStreaming: false,
+				isCompacting: false,
+				sessionManager,
+				agent: { state: {} },
+			} as never,
+			unsubscribe: () => {},
+			cwd: "/tmp",
+		});
+
+		await expect(backend.recallMessage("s1", { entryId })).resolves.toEqual({
+			text: "/skill:mindmap layout",
+			images: [],
+		});
+	});
+});

--- a/packages/backend/test/subagent-tool.test.ts
+++ b/packages/backend/test/subagent-tool.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import type { SingleResult } from "../src/tools/subagent/runner";
-import { finalizeSubagentResult } from "../src/tools/subagent/tool";
+import { finalizeSubagentResult, subagentParams } from "../src/tools/subagent/tool";
 
 function makeResult(overrides: Partial<SingleResult> = {}): SingleResult {
 	return {
@@ -12,6 +12,34 @@ function makeResult(overrides: Partial<SingleResult> = {}): SingleResult {
 		...overrides,
 	};
 }
+
+describe("subagentParams schema（provider 兼容，0.4.5 回归）", () => {
+	// SDK 发送前会 JSON 序列化 schema（symbol 键丢失），断言序列化后的形态最贴近真实请求
+	const schema = JSON.parse(JSON.stringify(subagentParams)) as Record<string, unknown>;
+
+	it("顶层必须是 type:object（DeepSeek 等 openai-completions 端点硬性要求）", () => {
+		expect(schema.type).toBe("object");
+	});
+
+	it("顶层不使用 anyOf/allOf 组合器（anthropic convertTools 会剥掉它们，剩空 schema）", () => {
+		expect(schema.anyOf).toBeUndefined();
+		expect(schema.allOf).toBeUndefined();
+	});
+
+	it("完整 properties：agent/task/cwd/tasks/confirmProjectAgents 均带描述", () => {
+		const props = schema.properties as Record<string, { description?: string }>;
+		expect(Object.keys(props)).toEqual(
+			expect.arrayContaining(["agent", "task", "cwd", "tasks", "confirmProjectAgents"]),
+		);
+		for (const key of ["agent", "task", "tasks"]) {
+			expect(props[key]?.description, `${key} 缺 description`).toBeTruthy();
+		}
+	});
+
+	it("所有字段 optional（互斥约束由 execute 运行时校验兜底）", () => {
+		expect(schema.required).toBeUndefined();
+	});
+});
 
 describe("finalizeSubagentResult（失败语义 spec §6）", () => {
 	it("single 成功：content 为结论，无 isError", () => {

--- a/packages/desktop/src/renderer/src/components/chat/MessageItem.tsx
+++ b/packages/desktop/src/renderer/src/components/chat/MessageItem.tsx
@@ -1,4 +1,4 @@
-import type { ImageInput } from "@percho/shared";
+import { formatSkillCommand, type ImageInput } from "@percho/shared";
 import { memo, type ReactNode, useEffect, useRef, useState } from "react";
 import { useT } from "../../i18n";
 import { Slot } from "../../plugins/Slot";
@@ -109,7 +109,15 @@ function ForkButton({ entryId, text }: { entryId?: string; text: string }) {
 }
 
 /** 撤回按钮：会话回退到该用户消息之前，内容放回输入框继续编辑；agent 运行或压缩中禁用 */
-function RecallButton({ entryId, text, timestamp }: { entryId?: string; text: string; timestamp: number }) {
+function RecallButton({
+	entryId,
+	matchText,
+	timestamp,
+}: {
+	entryId?: string;
+	matchText: string;
+	timestamp: number;
+}) {
 	const t = useT();
 	const activeSessionId = useSessionsStore((s) => s.activeSessionId);
 	const sessionBusy = useTranscriptStore((s) => {
@@ -127,8 +135,10 @@ function RecallButton({ entryId, text, timestamp }: { entryId?: string; text: st
 	const handleRecall = () => {
 		if (recalling || sessionBusy) return;
 		setRecalling(true);
-		// entryId 精确定位（历史消息）；实时消息无 entryId，按文本+时间戳兑底匹配
-		void recallMessage({ entryId, text: text || undefined, timestamp }).finally(() => setRecalling(false));
+		// entryId 精确定位（历史消息）；实时消息无 entryId，按持久化文本+时间戳兑底匹配
+		void recallMessage({ entryId, text: matchText || undefined, timestamp }).finally(() =>
+			setRecalling(false),
+		);
 	};
 
 	return (
@@ -184,15 +194,36 @@ export const MessageItem = memo(function MessageItem({
 							))}
 						</div>
 					)}
-					{message.text && (
-						<div className="rounded-2xl rounded-br-md bg-border px-3.5 py-2 text-[14px] leading-relaxed whitespace-pre-wrap text-ink select-text">
-							{message.text}
+					{message.skill ? (
+						<div className="rounded-2xl rounded-br-md bg-border px-3.5 py-2 text-[14px] leading-relaxed text-ink select-text">
+							<div
+								className={
+									message.text
+										? "mb-1 font-mono text-[12px] text-ink-dim"
+										: "font-mono text-[12px] text-ink-dim"
+								}
+							>
+								{t("message.skillInvocation", { name: message.skill.name })}
+							</div>
+							{message.text && <div className="whitespace-pre-wrap">{message.text}</div>}
 						</div>
+					) : (
+						message.text && (
+							<div className="rounded-2xl rounded-br-md bg-border px-3.5 py-2 text-[14px] leading-relaxed whitespace-pre-wrap text-ink select-text">
+								{message.text}
+							</div>
+						)
 					)}
-					{(message.text || message.images.length > 0) && (
+					{(message.skill || message.text || message.images.length > 0) && (
 						<div className="mt-1 flex items-center justify-end gap-1">
-							{message.text && <CopyButton text={message.text} />}
-							<RecallButton entryId={message.entryId} text={message.text} timestamp={message.timestamp} />
+							{(message.skill || message.text) && (
+								<CopyButton text={message.skill ? formatSkillCommand(message.skill) : message.text} />
+							)}
+							<RecallButton
+								entryId={message.entryId}
+								matchText={message.sourceText ?? message.text}
+								timestamp={message.timestamp}
+							/>
 						</div>
 					)}
 				</div>

--- a/packages/desktop/src/renderer/src/components/chat/MessageList.tsx
+++ b/packages/desktop/src/renderer/src/components/chat/MessageList.tsx
@@ -131,33 +131,18 @@ export function MessageList() {
 	/** 组序号：同会话内 key 按位置稳定（streaming→committed 转换不 remount，正文边界后的新组自增）；
 	 *  key 含会话 id：切会话强制 remount——shownWorking 滞后/预览行调度等组内本地状态不跨会话泄漏 */
 	let groupIndex = 0;
-	/** 最后一个 flush 的组（subagent 固化消息的计数补丁目标）；
-	 *  用 ref 对象持有：闭包内赋值会导致 let 变量被 TS 错误窄化成 null；渲染前可直接替换 items 数组元素 */
-	const lastGroup = {
-		current: null as null | {
-			at: number;
-			key: string;
-			groupItems: MetaItem[];
-			working: boolean;
-			endImmediately: boolean;
-			subagentCount: number;
-		},
-	};
-	/** subagent 消息找不到前序组时（整轮只有子代理）结转给下一个 flush 的组 */
-	let carrySubagentCount = 0;
 	/**
 	 * isLatest：是否为当前 run 的组（仅最后一个组接收 working 信号，历史组恒为已完成）
 	 * forceEmpty：agent 工作中即使无内容也渲染（占位与流式组一体：空组 = 工作中 + 思考中预览）
+	 * subagentCount：子代理没有普通工具卡，仍须生成所属的折叠状态行，让卡片按时间排在它正下方。
 	 */
-	const flushMeta = (isLatest = false, forceEmpty = false) => {
-		if (metaItems.length === 0 && !forceEmpty) return;
+	const flushMeta = (isLatest = false, forceEmpty = false, subagentCount = 0) => {
+		if (metaItems.length === 0 && !forceEmpty && subagentCount === 0) return;
 		// 正文在输出（组被正文边界切分）或 run 已终结 → working 信号消失时立即结束，不做滞后缓冲
 		const endImmediately = Boolean(transcript.streaming?.text) || !transcript.agentActive;
 		const key = `meta-${activeSessionId}-g${groupIndex++}`;
 		const groupItems = metaItems;
 		const working = isLatest && agentWorking;
-		const subagentCount = carrySubagentCount;
-		carrySubagentCount = 0;
 		items.push(
 			<MetaGroup
 				key={key}
@@ -167,45 +152,18 @@ export function MessageList() {
 				subagentCount={subagentCount}
 			/>,
 		);
-		lastGroup.current = {
-			at: items.length - 1,
-			key,
-			groupItems,
-			working,
-			endImmediately,
-			subagentCount,
-		};
 		metaItems = [];
 	};
 
 	for (const message of transcript.messages) {
 		if (message.kind === "subagent") {
-			// 子代理固化消息（turn_end 排在 assistant 之后）：先 flush 关闭本轮组，再把计数补丁
-			// 打给刚关闭的组（本轮工具所在组），统计行正向显示「子代理 ×N」（spec §9.0）；
-			// 没有任何前序组（整轮只有子代理）则结转下一个组
-			flushMeta();
-			const add = message.runs.length;
-			const g = lastGroup.current;
-			if (g) {
-				g.subagentCount += add;
-				items[g.at] = (
-					<MetaGroup
-						key={g.key}
-						items={g.groupItems}
-						working={g.working}
-						endImmediately={g.endImmediately}
-						subagentCount={g.subagentCount}
-					/>
-				);
-			} else {
-				carrySubagentCount += add;
-			}
+			// 子代理结果发生在调用工具之后：无论该轮是否还有普通工具/思考，都先落一条所属的
+			// 折叠状态行，再紧接卡片。不能回补“上一个”组，否则纯子代理轮会跳到前一轮顶部。
+			flushMeta(false, false, message.runs.length);
 			items.push(<MessageItem key={message.id} message={message} />);
 			continue;
 		}
 		if (message.kind !== "assistant") {
-			// user 消息 = 轮次硬边界：subagent 计数不允许跨轮补丁
-			if (message.kind === "user") lastGroup.current = null;
 			flushMeta();
 			items.push(<MessageItem key={message.id} message={message} />);
 			continue;
@@ -266,25 +224,24 @@ export function MessageList() {
 		if (postTools.length > 0) {
 			metaItems.push({ thinking: "", tools: postTools, activity: streaming.activity });
 		}
-		// 子代理运行中行：tool_execution_start 即入缓冲，流式期就展示（不等 turn_end 固化），顺序对齐固化后的 assistant → subagents
-		if (streaming.subagentRuns.length > 0) {
-			items.push(
-				<Slot
-					key="streaming-subagents"
-					name={UI_SLOTS.SubagentCard}
-					props={{ runs: streaming.subagentRuns }}
-					fallback={SubagentRunCard}
-				/>,
-			);
-		}
 	}
 	// 最新组无内容但仍在工作（正文已出、工具/子代理执行中）：挂上流式活动序列，预览行继续显示最新活动
 	if (metaItems.length === 0 && agentWorking && streaming && streaming.activity.length > 0) {
 		metaItems.push({ thinking: "", tools: [], activity: streaming.activity });
 	}
-	// 流式期的子代理运行归入当前 run 的最终组（固化后经 subagent 消息补丁前序组，两阶段不重复计数）
-	if (streaming) carrySubagentCount += streaming.subagentRuns.length;
-	flushMeta(true, agentWorking);
+	// 流式子代理也属于当前最后一条状态行：先 flush 状态行、后挂卡片，避免卡片倒挂在折叠行上方。
+	const streamingSubagentRuns = streaming?.subagentRuns ?? [];
+	flushMeta(true, agentWorking, streamingSubagentRuns.length);
+	if (streamingSubagentRuns.length > 0) {
+		items.push(
+			<Slot
+				key="streaming-subagents"
+				name={UI_SLOTS.SubagentCard}
+				props={{ runs: streamingSubagentRuns }}
+				fallback={SubagentRunCard}
+			/>,
+		);
+	}
 
 	return (
 		<div className="relative h-full">

--- a/packages/desktop/src/renderer/src/components/chat/MetaGroup.tsx
+++ b/packages/desktop/src/renderer/src/components/chat/MetaGroup.tsx
@@ -258,7 +258,8 @@ export function MetaGroup({
 
 	/** 单条已结束（如正文前的思考）直接裸行展示，不套 "已完成 · 1" 外壳；-mb-4 与包装组一致：
 	 * 与后续正文净距 8px（容器 gap-6 - 16px），单行/成组间距统一 */
-	const showWrapper = count >= 2 || shownWorking;
+	// 纯子代理调用不带普通 tool/thinking，仍须保留折叠状态行作为卡片的时间锚点。
+	const showWrapper = count >= 2 || shownWorking || subagentCount > 0;
 	if (!showWrapper) {
 		return <div className="-mb-4 flex flex-col gap-1.5">{rows}</div>;
 	}

--- a/packages/desktop/src/renderer/src/components/chat/SubagentRunCard.tsx
+++ b/packages/desktop/src/renderer/src/components/chat/SubagentRunCard.tsx
@@ -12,7 +12,8 @@ function SubagentRunRow({ run }: { run: SubagentRunUi }) {
 	const t = useT();
 	const openFromHistory = useSessionsStore((s) => s.openFromHistory);
 
-	const clickable = run.sessionFile != null && run.status !== "running";
+	// runner 创建会话文件后即回填 sessionFile；运行中同样允许打开只读检视页。
+	const clickable = run.sessionFile != null;
 	const statusLabel =
 		run.status === "running"
 			? t("message.subagent.running")

--- a/packages/desktop/src/renderer/src/components/chat/meta-summary.test.ts
+++ b/packages/desktop/src/renderer/src/components/chat/meta-summary.test.ts
@@ -79,6 +79,10 @@ describe("summarizeCategories", () => {
 			{ key: "read", category: "read", name: "read", count: 1 },
 			{ key: "subagent", category: "subagent", name: "subagent", count: 2 },
 		]);
+		// 纯子代理轮也有自己的折叠状态行：空组仍产出汇总段作为卡片的时间锚点
+		expect(summarizeCategories([{ tools: [] }], 1)).toEqual([
+			{ key: "subagent", category: "subagent", name: "subagent", count: 1 },
+		]);
 		// 无 subagent 的组（subagentCount=0）不显示该段
 		expect(summarizeCategories([{ tools: [tool("read")] }], 0)).toHaveLength(1);
 	});

--- a/packages/desktop/src/renderer/src/i18n/en.ts
+++ b/packages/desktop/src/renderer/src/i18n/en.ts
@@ -121,6 +121,7 @@ export const en: Messages = {
 		copied: "Copied",
 		recall: "Recall to composer",
 		fork: "Fork from here",
+		skillInvocation: "Skill · {name}",
 		scrollToBottom: "Back to bottom",
 		thinking: "Thinking",
 		thinkingPreview: "Thinking",

--- a/packages/desktop/src/renderer/src/i18n/zh.ts
+++ b/packages/desktop/src/renderer/src/i18n/zh.ts
@@ -118,6 +118,7 @@ export const zh = {
 		copied: "已复制",
 		recall: "撤回并放回输入框",
 		fork: "从此处分叉",
+		skillInvocation: "Skill · {name}",
 		scrollToBottom: "回到底部",
 		thinking: "思考过程",
 		thinkingPreview: "思考中",

--- a/packages/desktop/src/renderer/src/stores/sessions.test.ts
+++ b/packages/desktop/src/renderer/src/stores/sessions.test.ts
@@ -1,4 +1,4 @@
-import type { SessionMeta } from "@percho/shared";
+import type { SessionEvent, SessionMeta } from "@percho/shared";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 /** window.pi 的 mock：sessions store 经 getPi() 访问，测试环境无 preload 注入 */
@@ -11,10 +11,15 @@ const piMock = vi.hoisted(() => ({
 	saveUiState: vi.fn(),
 	pickDirectory: vi.fn(),
 	ensureProjectTrust: vi.fn(() => Promise.resolve(true)),
+	openSession: vi.fn(),
+	getSessionMessages: vi.fn(),
+	getFollowUpMessages: vi.fn(() => Promise.resolve([])),
+	getTodos: vi.fn(() => Promise.resolve([])),
 }));
 vi.mock("../api", () => ({ getPi: () => piMock }));
 
 import { DRAFT_SESSION_PREFIX, isDraftSessionId, useSessionsStore } from "./sessions";
+import { useTranscriptStore } from "./transcript";
 
 function realMeta(sessionId: string, cwd: string): SessionMeta {
 	return {
@@ -42,6 +47,7 @@ function resetStore() {
 beforeEach(() => {
 	vi.clearAllMocks();
 	resetStore();
+	useTranscriptStore.setState({ bySession: {} });
 });
 
 describe("isDraftSessionId", () => {
@@ -173,6 +179,19 @@ describe("switchSession", () => {
 		useSessionsStore.getState().switchSession(draftId);
 		expect(useSessionsStore.getState().cwd).toBe("/proj/b");
 		expect(piMock.saveTabs).toHaveBeenCalledTimes(1);
+	});
+});
+
+describe("openFromHistory", () => {
+	it("运行中子会话已收到实时事件时保留流式进度，不回放静态历史覆盖", async () => {
+		piMock.openSession.mockResolvedValue(realMeta("sub-1", "/proj"));
+		useTranscriptStore.getState().applyEvent("sub-1", { type: "agent_start" } as SessionEvent);
+
+		await useSessionsStore.getState().openFromHistory("/tmp/sub-1.jsonl");
+
+		expect(piMock.getSessionMessages).not.toHaveBeenCalled();
+		expect(useTranscriptStore.getState().bySession["sub-1"]?.agentActive).toBe(true);
+		expect(useSessionsStore.getState().activeSessionId).toBe("sub-1");
 	});
 });
 

--- a/packages/desktop/src/renderer/src/stores/sessions.ts
+++ b/packages/desktop/src/renderer/src/stores/sessions.ts
@@ -189,8 +189,13 @@ export const useSessionsStore = create<SessionsStore>((set, get) => ({
 				activeSessionId: meta.sessionId,
 				cwd: meta.cwd,
 			}));
-			const history = await getPi().getSessionMessages(meta.sessionId);
-			useTranscriptStore.getState().loadHistory(meta.sessionId, messagesToUIMessages(history));
+			// 运行中子会话的事件已按其 sessionId 实时转发；保留已有流式态，
+			// 否则会在点击卡片时把 agent_start 建立的进度视图重置为静态历史。
+			const hasLiveTranscript = useTranscriptStore.getState().bySession[meta.sessionId]?.agentActive;
+			if (!hasLiveTranscript) {
+				const history = await getPi().getSessionMessages(meta.sessionId);
+				useTranscriptStore.getState().loadHistory(meta.sessionId, messagesToUIMessages(history));
+			}
 			const followUpQueue = await getPi().getFollowUpMessages(meta.sessionId);
 			useTranscriptStore.getState().setFollowUpQueue(meta.sessionId, followUpQueue);
 			const todos = await getPi().getTodos(meta.sessionId);

--- a/packages/desktop/src/renderer/src/stores/transcript-reducer/mapping.ts
+++ b/packages/desktop/src/renderer/src/stores/transcript-reducer/mapping.ts
@@ -23,7 +23,7 @@ export function messagesToUIMessages(messages: SessionMessage[]): UIMessage[] {
 			continue;
 		}
 		if (m.role === "user") {
-			if (m.text || m.images.length > 0) {
+			if (m.skill || m.text || m.images.length > 0) {
 				ui.push({
 					kind: "user",
 					id,
@@ -31,6 +31,8 @@ export function messagesToUIMessages(messages: SessionMessage[]): UIMessage[] {
 					images: m.images,
 					timestamp: m.timestamp,
 					entryId: m.entryId,
+					skill: m.skill,
+					sourceText: m.sourceText,
 				});
 			}
 			continue;

--- a/packages/desktop/src/renderer/src/stores/transcript-reducer/reducer.ts
+++ b/packages/desktop/src/renderer/src/stores/transcript-reducer/reducer.ts
@@ -2,6 +2,7 @@ import {
 	extractSubagentRuns,
 	extractTodos,
 	type ImageInput,
+	parseExpandedSkillInvocation,
 	type SessionEvent,
 	TODO_TOOL_NAME,
 } from "@percho/shared";
@@ -144,6 +145,7 @@ export function reduceEvent(state: SessionTranscriptState, event: SessionEvent):
 							.filter((c) => c.type === "text")
 							.map((c) => (c as { text: string }).text)
 							.join("");
+			const invocation = parseExpandedSkillInvocation(text);
 			const images: ImageInput[] = Array.isArray(content)
 				? content
 						.filter((c) => c.type === "image" && (c as { data?: string }).data)
@@ -159,9 +161,12 @@ export function reduceEvent(state: SessionTranscriptState, event: SessionEvent):
 					{
 						kind: "user",
 						id: newMessageId(),
-						text,
+						text: invocation ? (invocation.args ?? "") : text,
 						images,
 						timestamp: event.message.timestamp ?? Date.now(),
+						...(invocation
+							? { skill: { name: invocation.name, args: invocation.args }, sourceText: text }
+							: {}),
 					},
 				],
 			};

--- a/packages/desktop/src/renderer/src/stores/transcript-reducer/reducer.ts
+++ b/packages/desktop/src/renderer/src/stores/transcript-reducer/reducer.ts
@@ -324,11 +324,35 @@ export function reduceEvent(state: SessionTranscriptState, event: SessionEvent):
 			const streaming = state.streaming;
 			if (!streaming) return state;
 			const delta = extractExecutionDelta(event.partialResult);
-			if (!delta) return state;
-			const tools = streaming.tools.map((t) =>
-				t.id === event.toolCallId ? { ...t, output: t.output + delta } : t,
-			);
-			return { ...state, streaming: { ...streaming, tools } };
+			const placement = streaming.subagentByToolCallId[event.toolCallId];
+			const progress = placement
+				? extractSubagentRuns((event.partialResult as { details?: unknown } | null | undefined)?.details)
+				: null;
+			let subagentRuns = streaming.subagentRuns;
+			if (placement && progress) {
+				// 子会话在 runner 创建后立即通过 partialResult 上报 sessionFile；只回填路径，
+				// 保住 running 状态（其 exitCode=-1，不能被 extract 的 error 判定覆盖）。
+				const next = [...subagentRuns];
+				for (const update of progress) {
+					if (!update.sessionFile) continue;
+					const index = next.findIndex(
+						(run, i) =>
+							i >= placement.start &&
+							i < placement.start + placement.count &&
+							run.sessionFile == null &&
+							run.agent === update.agent &&
+							(update.task == null || run.task === update.task),
+					);
+					const current = index >= 0 ? next[index] : undefined;
+					if (current) next[index] = { ...current, sessionFile: update.sessionFile };
+				}
+				subagentRuns = next;
+			}
+			if (!delta && subagentRuns === streaming.subagentRuns) return state;
+			const tools = delta
+				? streaming.tools.map((t) => (t.id === event.toolCallId ? { ...t, output: t.output + delta } : t))
+				: streaming.tools;
+			return { ...state, streaming: { ...streaming, tools, subagentRuns } };
 		}
 		case "tool_execution_end": {
 			// todo 工具：全量替换会话任务列表（含空数组=清空）。不随 turn_end 清理、

--- a/packages/desktop/src/renderer/src/stores/transcript-reducer/types.ts
+++ b/packages/desktop/src/renderer/src/stores/transcript-reducer/types.ts
@@ -1,4 +1,4 @@
-import type { ImageInput, TodoItem } from "@percho/shared";
+import type { ImageInput, SkillInvocationDisplay, TodoItem } from "@percho/shared";
 
 /** 会话 UI 态类型（transcript reducer 的状态形状） */
 
@@ -27,6 +27,10 @@ export type UIMessage =
 			timestamp: number;
 			/** 会话树 entry id（仅历史回放消息有；撤回精确定位，缺省时按文本+时间戳兑底） */
 			entryId?: string;
+			/** 已展开 skill 的安全展示信息（不含正文或路径） */
+			skill?: SkillInvocationDisplay;
+			/** 完整持久化文本，仅供实时撤回匹配；绝不能渲染、复制或进入可访问文本 */
+			sourceText?: string;
 	  }
 	| {
 			kind: "assistant";

--- a/packages/desktop/src/renderer/src/stores/transcript.test.ts
+++ b/packages/desktop/src/renderer/src/stores/transcript.test.ts
@@ -7,6 +7,9 @@ function ev(type: string, extra: Record<string, unknown> = {}): AgentSessionEven
 	return { type, ...extra } as AgentSessionEvent;
 }
 
+const canonicalSkill = (args?: string) =>
+	`<skill name="mindmap" location="/tmp/skills/mindmap/SKILL.md">\nReferences are relative to /tmp/skills/mindmap.\n\n# Mind map\n\nBody\n</skill>${args ? `\n\n${args}` : ""}`;
+
 describe("transcript reducer", () => {
 	it("subagent 互斥事件生成系统消息（结构化 + 同扩展去重）", () => {
 		let state = reduceEvent(emptyTranscript(), {
@@ -43,6 +46,31 @@ describe("transcript reducer", () => {
 		} as unknown as AgentSessionEvent);
 		expect(state.messages).toHaveLength(1);
 		expect(state.messages[0]).toMatchObject({ kind: "user", text: "你好" });
+	});
+
+	it("canonical skill 用户消息紧凑投影，并保留 sourceText 供撤回定位", () => {
+		let state = reduceEvent(emptyTranscript(), {
+			type: "message_start",
+			message: { role: "user", content: canonicalSkill("topic\nmore"), timestamp: 1720000000000 },
+		} as unknown as AgentSessionEvent);
+		expect(state.messages[0]).toMatchObject({
+			kind: "user",
+			text: "topic\nmore",
+			skill: { name: "mindmap", args: "topic\nmore" },
+			sourceText: canonicalSkill("topic\nmore"),
+			timestamp: 1720000000000,
+		});
+
+		state = reduceEvent(emptyTranscript(), {
+			type: "message_start",
+			message: { role: "user", content: canonicalSkill() },
+		} as unknown as AgentSessionEvent);
+		expect(state.messages[0]).toMatchObject({
+			kind: "user",
+			text: "",
+			skill: { name: "mindmap", args: undefined },
+			sourceText: canonicalSkill(),
+		});
 	});
 
 	it("用户消息透传 SDK timestamp（撤回兑底定位用），缺省回退本地时间", () => {
@@ -1053,6 +1081,39 @@ describe("messagesToUIMessages 历史回放", () => {
 		]);
 		expect(ui[0]).toMatchObject({ kind: "user", entryId: "e1" });
 		expect(ui[1]).not.toHaveProperty("entryId", "e1");
+	});
+
+	it("skill 历史消息保留紧凑元数据与 sourceText", () => {
+		const sourceText = canonicalSkill("layout");
+		const ui = messagesToUIMessages([
+			{
+				role: "user",
+				text: "layout",
+				thinking: "",
+				tools: [],
+				images: [],
+				timestamp: 1,
+				skill: { name: "mindmap", args: "layout" },
+				sourceText,
+			},
+			{
+				role: "user",
+				text: "",
+				thinking: "",
+				tools: [],
+				images: [],
+				timestamp: 2,
+				skill: { name: "mindmap", args: undefined },
+				sourceText: canonicalSkill(),
+			},
+		]);
+		expect(ui[0]).toMatchObject({
+			kind: "user",
+			text: "layout",
+			skill: { name: "mindmap", args: "layout" },
+			sourceText,
+		});
+		expect(ui[1]).toMatchObject({ kind: "user", text: "", skill: { name: "mindmap", args: undefined } });
 	});
 
 	it("image 角色消息还原为图片消息，位置保持", () => {

--- a/packages/desktop/src/renderer/src/stores/transcript.test.ts
+++ b/packages/desktop/src/renderer/src/stores/transcript.test.ts
@@ -697,6 +697,39 @@ describe("transcript reducer", () => {
 		});
 	});
 
+	it("subagent：progress 在运行中回填 sessionFile，保住 running 状态", () => {
+		let state = emptyTranscript();
+		state = reduceEvent(state, ev("agent_start"));
+		state = reduceEvent(state, {
+			type: "tool_execution_start",
+			toolCallId: "tc-progress",
+			toolName: "subagent",
+			args: { agent: "reviewer", task: "review diff" },
+		} as unknown as AgentSessionEvent);
+		state = reduceEvent(state, {
+			type: "tool_execution_update",
+			toolCallId: "tc-progress",
+			toolName: "subagent",
+			partialResult: {
+				details: {
+					mode: "single",
+					results: [
+						{
+							agent: "reviewer",
+							task: "review diff",
+							exitCode: -1,
+							artifactPaths: { jsonlPath: "/tmp/subagent-running.jsonl" },
+						},
+					],
+				},
+			},
+		} as unknown as AgentSessionEvent);
+		expect(state.streaming?.subagentRuns[0]).toMatchObject({
+			status: "running",
+			sessionFile: "/tmp/subagent-running.jsonl",
+		});
+	});
+
 	it("subagent：tool_execution_start 移出折叠区时同步摘除 ticker 活动条目（不进 Working 预览行）", () => {
 		let state = emptyTranscript();
 		state = reduceEvent(state, ev("agent_start"));

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -2,6 +2,7 @@ export * from "./ipc";
 export * from "./packages";
 export * from "./session";
 export * from "./settings";
+export * from "./skill-invocation";
 export * from "./subagent";
 export * from "./todo";
 export * from "./ui-plugins";

--- a/packages/shared/src/session.ts
+++ b/packages/shared/src/session.ts
@@ -1,4 +1,5 @@
 import type { AgentSessionEvent as PiAgentSessionEvent } from "@earendil-works/pi-coding-agent";
+import type { SkillInvocationDisplay } from "./skill-invocation";
 import type { SubagentRunData } from "./subagent";
 
 /** 顶栏打开的会话持久化（重启恢复用，由主进程写入 userData/tabs.json） */
@@ -78,19 +79,39 @@ export interface SessionToolCall {
 	isError: boolean;
 }
 
+/** 历史 user 消息（打开历史会话时回放用；不依赖 pi 内部类型） */
+export interface SessionUserMessage {
+	role: "user";
+	text: string;
+	thinking: string;
+	tools: SessionToolCall[];
+	/** user 消息附带的图片 */
+	images: ImageInput[];
+	timestamp: number;
+	/** 会话树中的 entry id（撤回精确定位用，匹配失败时缺省） */
+	entryId?: string;
+	/** 已展开 skill 的安全展示信息（不含正文或路径） */
+	skill?: SkillInvocationDisplay;
+	/** 已持久化的完整文本；只供实时撤回匹配，绝不能展示、复制或进入可访问文本 */
+	sourceText?: string;
+}
+
+/** 历史 assistant 消息（打开历史会话时回放用；不依赖 pi 内部类型） */
+export interface SessionAssistantMessage {
+	role: "assistant";
+	text: string;
+	thinking: string;
+	tools: SessionToolCall[];
+	images: ImageInput[];
+	timestamp: number;
+	/** 会话树中的 entry id（fork 精确定位用，匹配失败时缺省） */
+	entryId?: string;
+}
+
 /** 历史会话消息（打开历史会话时回放用；不依赖 pi 内部类型） */
 export type SessionMessage =
-	| {
-			role: "user" | "assistant";
-			text: string;
-			thinking: string;
-			tools: SessionToolCall[];
-			/** user 消息附带的图片 */
-			images: ImageInput[];
-			timestamp: number;
-			/** 会话树中的 entry id（assistant/user 消息均有；fork·撤回定位用，匹配失败时缺省） */
-			entryId?: string;
-	  }
+	| SessionUserMessage
+	| SessionAssistantMessage
 	| {
 			/** show_image 工具主动展示给用户的图片（独立消息，不进工具卡） */
 			role: "image";

--- a/packages/shared/src/skill-invocation.ts
+++ b/packages/shared/src/skill-invocation.ts
@@ -1,0 +1,33 @@
+/** A successfully expanded SDK `/skill:` command, parsed from its persisted canonical text. */
+export interface SkillInvocation {
+	name: string;
+	/** SDK skill file path. Kept for parsing/tests only; never render it. */
+	location: string;
+	args?: string;
+}
+
+/** The safe subset used for UI presentation and command restoration. */
+export type SkillInvocationDisplay = Pick<SkillInvocation, "name" | "args">;
+
+/**
+ * Parses only the SDK 0.84 `_expandSkillCommand()` producer format. The references line
+ * deliberately distinguishes real expanded skills from the SDK helper's broader XML grammar.
+ */
+export function parseExpandedSkillInvocation(text: string): SkillInvocation | null {
+	const match = text.match(
+		/^<skill name="([^"]+)" location="([^"]+)">\nReferences are relative to [^\n]+\.\n\n[\s\S]*?\n<\/skill>(?:\n\n([\s\S]+))?$/,
+	);
+	if (!match) return null;
+	const [, name, location, rawArgs] = match;
+	if (!name || !location) return null;
+	return {
+		name,
+		location,
+		args: rawArgs?.trim() || undefined,
+	};
+}
+
+/** Rebuilds the reusable command without exposing the expanded body or source path. */
+export function formatSkillCommand({ name, args }: SkillInvocationDisplay): string {
+	return args ? `/skill:${name} ${args}` : `/skill:${name}`;
+}


### PR DESCRIPTION
## 问题

0.4.5 引入的内置 `subagent` 工具参数 schema 用了 `Type.Union(Type.Intersect(...))`，顶层只有 `anyOf` 没有 `type:"object"`：

- **DeepSeek（openai-completions 路径）**：SDK 原样发送 schema（`parameters: tool.parameters`），DeepSeek 硬性要求 `type:"object"`，直接 **400 拒掉整个请求** → 用户看到「没回复」（assistant 空消息 + `stopReason:error`）。会话日志铁证：`Invalid schema for function 'subagent': schema must be a JSON Schema of 'type: "object"', got 'type: null'`
- **kimi（anthropic-messages 路径）**：SDK `convertTools` 的 `legacyInputSchema` 只保留顶层 `properties/required`，Union 的 `anyOf` 被剥成 `{type:object, properties:{}, required:[]}` 空 schema → 模型看不到任何参数描述，是工具调用异常/断流的诱因

## 修复

- schema 拍平为单一 `Type.Object`（全字段 Optional，保留完整 description），两条 API 路径都正常
- 原 Union 的 single/parallel 互斥约束下沉到 `execute` 运行时校验（缺 `agent`/`task` 抛带指引的错误，模型可自愈重试）
- 导出 `subagentParams` + 4 个 schema 形状回归测试（顶层 type/无 anyOf/properties 完整/无 required）

## 验证

- [x] `npm run typecheck` 全绿；backend 220 tests 全过
- [x] 真实 DeepSeek 端点：旧 schema 复现与会话日志一字不差的 400 → 新 schema 200 正常回复
- [x] 真实 kimi 端点（模拟 SDK legacyInputSchema 转换）：200 正常

## 顺带说明（不在本 PR 修）

排查中发现 kimi 另有 `signature: malformed encrypted reasoning content` 400（8/20 出现两次后自愈，8/19 也有网络类错误），属 kimi 端对历史 thinking signature 的校验行为，与 0.4.5 无关。