### PR TITLE
feat(chat): streaming marquee for live preview rows

### DIFF
--- a/packages/desktop/src/renderer/src/components/chat/MetaGroup.tsx
+++ b/packages/desktop/src/renderer/src/components/chat/MetaGroup.tsx
@@ -221,20 +221,17 @@ export function MetaGroup({
 	const orbState: OrbState = isTool ? "connecting" : "working";
 	const labelKey = isTool ? "message.working" : "message.thinkingLabel";
 
-	// 实时预览：流式项的活动序列按到达顺序展开（latest-wins，预览行显示最后一条）
-	// 过滤掉 thinking：只显示 tool call，避免与标签栏的“思考中”重复
+	// 实时预览：完整活动序列按到达顺序展开，ticker 在 thinking/tool 间保持 latest-wins。
+	// 内容已由 reducer 分块累计；这里不重新合并、解析或摘要。
 	const liveItems = useMemo<LivePreviewItem[]>(() => {
 		const out: LivePreviewItem[] = [];
 		for (const item of items) {
 			if (!item.activity) continue;
 			for (const entry of item.activity) {
-				if (entry.kind === "tool") {
-					out.push({
-						kind: "tool",
-						id: entry.id,
-						name: entry.name ?? "tool",
-						args: entry.args ?? "",
-					});
+				if (entry.kind === "thinking") {
+					out.push({ kind: "thinking", id: entry.id, text: entry.text });
+				} else {
+					out.push({ kind: "tool", id: entry.id, name: entry.name, text: entry.args });
 				}
 			}
 		}

--- a/packages/desktop/src/renderer/src/components/chat/PreviewTicker.tsx
+++ b/packages/desktop/src/renderer/src/components/chat/PreviewTicker.tsx
@@ -1,51 +1,41 @@
-import { type ReactNode, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
-import { useT } from "../../i18n";
+import { useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import { type ActivityTickerSnapshot, createActivityTicker } from "./activity-ticker";
-import { displayName, summarizeArgs } from "./ToolCallCard";
+import { StreamingMarquee } from "./StreamingMarquee";
+import { displayName } from "./ToolCallCard";
 
 /** 预览条目（由 MetaGroup 从流式 activity 派生，按到达顺序） */
 export type LivePreviewItem =
-	| { kind: "tool"; id: string; name: string; args: string }
-	| { kind: "thinking"; id: string };
+	| { kind: "thinking"; id: string; text: string }
+	| { kind: "tool"; id: string; name: string; text: string };
 
-/** 当前屏上的 slot（渲染用） */
-interface CurrentSlot {
-	id: string;
-	kind: "tool" | "thinking";
-	name?: string;
-	args?: string;
-}
+type CurrentSlot = LivePreviewItem;
 
-/** thinking 预览行：只有"思考中"标签，不显示思考内容 */
-function ThinkingPreviewRow() {
-	const t = useT();
+/** thinking 行的固定身份在 MetaGroup；此处只显示对应的流式正文。 */
+function ThinkingPreviewRow({ text }: { text: string }) {
 	return (
-		<div className="flex items-center gap-2 py-0.5">
-			<span className="shrink-0 text-[13px] font-semibold text-ink-dim">{t("message.thinkingPreview")}</span>
+		<div className="flex min-w-0 items-center py-0.5 text-[13px] text-ink-dim">
+			<StreamingMarquee text={text} />
 		</div>
 	);
 }
 
-/** tool 预览行：工具名（data-shimmer-name：MetaGroup 统一扫光的范围终点；sweep-target：扫光样式兜底，挂载/清理无闪帧）+ 参数摘要（单行截断），不可展开；参数随流式增长原地更新 */
-function ToolPreviewRow({ name, args }: { name: string; args: string }) {
-	const summary = summarizeArgs(args);
+/** 工具名保持固定，参数原文作为流式正文横移；不沿用 ToolCallCard 的摘要逻辑。 */
+function ToolPreviewRow({ name, text }: { name: string; text: string }) {
 	return (
-		<div className="flex items-center gap-2 py-0.5">
+		<div className="flex min-w-0 items-center gap-2 py-0.5">
 			<span data-shimmer-name className="sweep-target shrink-0 font-mono text-[13px] text-ink-working">
 				{displayName(name)}
 			</span>
-			{summary && (
-				<span className="min-w-0 flex-1 truncate font-mono text-[12px] text-ink-faint">{summary}</span>
-			)}
+			{text && <StreamingMarquee text={text} />}
 		</div>
 	);
 }
 
-function rowOf(slot: CurrentSlot): ReactNode {
-	return slot.kind === "tool" && slot.name ? (
-		<ToolPreviewRow name={slot.name} args={slot.args ?? ""} />
+function rowOf(slot: CurrentSlot) {
+	return slot.kind === "tool" ? (
+		<ToolPreviewRow name={slot.name} text={slot.text} />
 	) : (
-		<ThinkingPreviewRow />
+		<ThinkingPreviewRow text={slot.text} />
 	);
 }
 
@@ -57,11 +47,10 @@ const PREV_CLEANUP_MS = ANIMATION_MS + 60;
 /**
  * 工作中预览行：永远显示最新一条活动（latest-wins）。
  * - 新活动上滑替换旧的；最小停留期内的爆发合并为最新一条（调度见 activity-ticker.ts）
- * - 同一活动参数增长只更新内容，不触发切换动画
- * - 切换动画串行化：一次滑入/滑出必放完，期间到达的切换合并为最新、在动画结束瞬间提交；
- *   活动清空也走滑出动画（不瞬时卸载）
- * - 无活动且无在屏动画时不渲染（思考中只在真 thinking 流式时出现）；
- *   reserveSpace 时改为渲染空占位行（working 期间高度恒定，避免下方内容随活动间隙上下跳）
+ * - 同一活动内容增长只更新内容，不触发切换动画
+ * - 切换动画串行化：一次滑入/滑出必放完，期间到达的切换合并为最新、在动画结束瞬间提交
+ * - 无活动且无在屏动画时不渲染（思考中只在真 thinking 流式时出现）
+ * - reserveSpace 时渲染空占位行，避免 tool call 间隙造成布局跳动
  */
 export function PreviewTicker({
 	items,
@@ -70,7 +59,6 @@ export function PreviewTicker({
 	items: LivePreviewItem[];
 	reserveSpace?: boolean;
 }) {
-	// useState 惰性初始化：调度器实例跨渲染稳定（同一引用）
 	const [ticker] = useState(createActivityTicker);
 	const [snap, setSnap] = useState<ActivityTickerSnapshot>(() => ticker.peek());
 	const [shown, setShownState] = useState<CurrentSlot | null>(null);
@@ -80,16 +68,16 @@ export function PreviewTicker({
 	/** 当前切换动画的结束时刻（此前不得发起下一次切换） */
 	const animUntilRef = useRef(0);
 
-	const slots = useMemo(() => items.map((i) => ({ id: i.id, kind: i.kind })), [items]);
+	const slots = useMemo(() => items.map((item) => ({ id: item.id, kind: item.kind })), [items]);
 
-	// 调度：items 变化（新活动/参数增长）→ latest-wins 判定；快照未变时保持旧引用 bail out
 	// biome-ignore lint/correctness/useExhaustiveDependencies: ticker 由 useState 惰性初始化，实例跨渲染恒定
 	useEffect(() => {
 		const next = ticker.ingest(slots, Date.now());
-		setSnap((prev) => (prev.currentId === next.currentId && prev.switchAt === next.switchAt ? prev : next));
+		setSnap((current) =>
+			current.currentId === next.currentId && current.switchAt === next.switchAt ? current : next,
+		);
 	}, [slots]);
 
-	// 最小停留到点 → 切到最新（合并停留期间到达的多条）
 	// biome-ignore lint/correctness/useExhaustiveDependencies: ticker 实例跨渲染恒定
 	useEffect(() => {
 		if (!snap.switchAt) return;
@@ -98,39 +86,34 @@ export function PreviewTicker({
 		return () => clearTimeout(timer);
 	}, [snap]);
 
-	// 目标 slot：无活动 → null（走滑出后消失）
-	const live = snap.currentId ? items.find((i) => i.id === snap.currentId) : undefined;
-	const desired: CurrentSlot | null = live
-		? live.kind === "tool"
-			? { id: live.id, kind: "tool", name: live.name, args: live.args }
-			: { id: live.id, kind: "thinking" }
-		: null;
+	const live = snap.currentId ? items.find((item) => item.id === snap.currentId) : undefined;
+	const desired = live ?? null;
 	desiredRef.current = desired;
 
-	// 提交切换：旧行挪到 previous 滑出，新行上屏；此后 ANIMATION_MS 内不再切换（动画放完）
 	const commit = (next: CurrentSlot | null) => {
-		const cur = shownRef.current;
-		if (cur && cur.id !== next?.id) setPrevious(cur);
+		const current = shownRef.current;
+		if (current && current.id !== next?.id) setPrevious(current);
 		animUntilRef.current = Date.now() + ANIMATION_MS;
 		shownRef.current = next;
 		setShownState(next);
 	};
 
-	// 切换决策：同 id → 原地内容更新；异 id → 动画空闲立即提交，动画中延迟到放完
-	// （延迟期间 desired 继续更新，提交时取最新 → 爆发合并为一跳，每跳都是完整动画）。
-	// 必须用 useLayoutEffect（paint 前同步 flush）：旧行滑出与新行滑入同一帧开始
-	// biome-ignore lint/correctness/useExhaustiveDependencies: commit/ refs 均为稳定引用
+	// 同 id 内容增长原地更新；异 id 才提交纵向滑动。layout effect 保证进/出场同帧开始。
+	// biome-ignore lint/correctness/useExhaustiveDependencies: commit/refs 均为稳定引用
 	useLayoutEffect(() => {
-		const cur = shownRef.current;
-		if (desired && desired.id === cur?.id) {
-			// 同一活动参数增长：内容原地更新（不动画、不重置计时）
-			if (desired.name !== cur.name || desired.args !== cur.args) {
+		const current = shownRef.current;
+		if (desired && desired.id === current?.id) {
+			if (
+				desired.kind !== current.kind ||
+				desired.text !== current.text ||
+				(desired.kind === "tool" && current.kind === "tool" && desired.name !== current.name)
+			) {
 				shownRef.current = desired;
 				setShownState(desired);
 			}
 			return;
 		}
-		if (desired === null && cur === null) return;
+		if (desired === null && current === null) return;
 		const wait = animUntilRef.current - Date.now();
 		if (wait <= 0) {
 			commit(desired);
@@ -140,20 +123,15 @@ export function PreviewTicker({
 		return () => clearTimeout(timer);
 	}, [desired]);
 
-	// previous 兜底清理（动画未触发 / motion-reduce 时也能移除）
 	useEffect(() => {
 		if (!previous) return;
 		const timer = setTimeout(() => setPrevious(null), PREV_CLEANUP_MS);
 		return () => clearTimeout(timer);
 	}, [previous]);
 
-	if (!shown && !previous) {
-		// working 期间占位：tool call 间隙不卸载，高度恒为 h-6，消除触底时布局跳动
-		return reserveSpace ? <div className="relative h-6 overflow-hidden" /> : null;
-	}
+	if (!shown && !previous) return reserveSpace ? <div className="relative h-6 overflow-hidden" /> : null;
 
 	return (
-		// 上下边缘 mask 渐隐：滑入/滑出行穿过容器边界时柔化，避免硬裁切边（静态行文字居中不受影响）
 		<div className="relative h-6 overflow-hidden text-ink-dim [mask-image:linear-gradient(to_bottom,transparent,black_20%,black_80%,transparent)]">
 			{previous && (
 				<div key={`prev-${previous.id}`} className="preview-slide-out absolute inset-x-0 top-0">

--- a/packages/desktop/src/renderer/src/components/chat/StreamingMarquee.tsx
+++ b/packages/desktop/src/renderer/src/components/chat/StreamingMarquee.tsx
@@ -1,0 +1,69 @@
+import { useEffect, useLayoutEffect, useRef, useState } from "react";
+import { tailOffsetForWidths } from "./marquee-motion";
+
+/**
+ * 流式预览的 tail-follow：文本每次增长后立即右对齐，保持最新 token 在视口末端。
+ */
+export function StreamingMarquee({ text }: { text: string }) {
+	const viewportRef = useRef<HTMLDivElement>(null);
+	const primaryRef = useRef<HTMLSpanElement>(null);
+	const trackRef = useRef<HTMLDivElement>(null);
+	const measureRef = useRef<() => void>(() => {});
+	const [metrics, setMetrics] = useState({ viewportWidth: 0, textWidth: 0 });
+	const [reducedMotion, setReducedMotion] = useState(
+		() => window.matchMedia("(prefers-reduced-motion: reduce)").matches,
+	);
+	const overflowing = metrics.textWidth > metrics.viewportWidth;
+	const offset = reducedMotion ? 0 : tailOffsetForWidths(metrics.textWidth, metrics.viewportWidth);
+
+	useEffect(() => {
+		const media = window.matchMedia("(prefers-reduced-motion: reduce)");
+		const update = () => setReducedMotion(media.matches);
+		update();
+		media.addEventListener("change", update);
+		return () => media.removeEventListener("change", update);
+	}, []);
+
+	useLayoutEffect(() => {
+		const viewport = viewportRef.current;
+		const primary = primaryRef.current;
+		if (!viewport || !primary) return;
+		const measure = () => {
+			const next = { viewportWidth: viewport.clientWidth, textWidth: primary.scrollWidth };
+			setMetrics((current) =>
+				current.viewportWidth === next.viewportWidth && current.textWidth === next.textWidth ? current : next,
+			);
+		};
+		measureRef.current = measure;
+		measure();
+		const observer = new ResizeObserver(measure);
+		observer.observe(viewport);
+		observer.observe(primary);
+		return () => {
+			observer.disconnect();
+			measureRef.current = () => {};
+		};
+	}, []);
+
+	// 文本 delta 不一定改变主 span 的布局盒尺寸，commit 后补量 scrollWidth 以立即追随最新 token。
+	useLayoutEffect(() => {
+		measureRef.current();
+	});
+
+	useLayoutEffect(() => {
+		if (trackRef.current) trackRef.current.style.transform = `translate3d(-${offset}px, 0, 0)`;
+	}, [offset]);
+
+	return (
+		<div
+			ref={viewportRef}
+			className="min-w-0 flex-1 overflow-hidden whitespace-nowrap [mask-image:linear-gradient(to_right,transparent,black_4%,black_96%,transparent)]"
+		>
+			<div ref={trackRef} className={overflowing ? "w-max" : "min-w-0 truncate"}>
+				<span ref={primaryRef} className={overflowing ? "block" : "block truncate"}>
+					{text}
+				</span>
+			</div>
+		</div>
+	);
+}

--- a/packages/desktop/src/renderer/src/components/chat/marquee-motion.test.ts
+++ b/packages/desktop/src/renderer/src/components/chat/marquee-motion.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+import { tailOffsetForWidths } from "./marquee-motion";
+
+describe("streaming preview tail-follow motion", () => {
+	it("无效尺寸时停在开头", () => {
+		expect(tailOffsetForWidths(Number.NaN, 100)).toBe(0);
+		expect(tailOffsetForWidths(100, Number.POSITIVE_INFINITY)).toBe(0);
+	});
+
+	it("未溢出时停在开头", () => {
+		expect(tailOffsetForWidths(80, 100)).toBe(0);
+		expect(tailOffsetForWidths(100, 100)).toBe(0);
+	});
+
+	it("溢出时右对齐到最新文本", () => {
+		expect(tailOffsetForWidths(140, 100)).toBe(40);
+	});
+
+	it("文本增长时以增长量同步推进", () => {
+		const initial = tailOffsetForWidths(140, 100);
+		const afterDelta = tailOffsetForWidths(167, 100);
+		expect(afterDelta - initial).toBe(27);
+	});
+
+	it("视口增长时回退到仍可见的最近位置", () => {
+		expect(tailOffsetForWidths(167, 140)).toBe(27);
+	});
+});

--- a/packages/desktop/src/renderer/src/components/chat/marquee-motion.ts
+++ b/packages/desktop/src/renderer/src/components/chat/marquee-motion.ts
@@ -1,0 +1,10 @@
+/** 无 DOM 的流式正文 tail-follow 位置计算。 */
+
+/**
+ * 将动态文本的右缘贴到视口右缘，令最新 token 始终可见。
+ * 无效尺寸或未溢出时停在开头。
+ */
+export function tailOffsetForWidths(textWidth: number, viewportWidth: number): number {
+	if (!Number.isFinite(textWidth) || !Number.isFinite(viewportWidth)) return 0;
+	return Math.max(0, textWidth - viewportWidth);
+}

--- a/packages/desktop/src/renderer/src/stores/transcript-reducer/helpers.ts
+++ b/packages/desktop/src/renderer/src/stores/transcript-reducer/helpers.ts
@@ -56,14 +56,29 @@ export function toolNameFromPartial(partial: unknown, contentIndex: number): str
 	return "tool";
 }
 
+/** thinking 按 content block 累积；同一块原地更新，首次到达按顺序追加。 */
+export function updateThinkingActivity(
+	activity: ActivityEntry[],
+	contentIndex: number,
+	append: (text: string) => string,
+): ActivityEntry[] {
+	const id = `h${contentIndex}`;
+	const existing = activity.find((entry) => entry.id === id);
+	if (!existing) return [...activity, { id, kind: "thinking", text: append("") }];
+	return activity.map((entry) =>
+		entry.id === id && entry.kind === "thinking" ? { ...entry, text: append(entry.text) } : entry,
+	);
+}
+
 export function updateToolActivity(
 	activity: ActivityEntry[],
 	contentIndex: number,
 	append: (args: string) => string,
 ): ActivityEntry[] {
 	const id = `c${contentIndex}`;
-	if (!activity.some((a) => a.id === id)) return activity;
-	return activity.map((a) => (a.id === id ? { ...a, args: append(a.args ?? "") } : a));
+	return activity.map((entry) =>
+		entry.id === id && entry.kind === "tool" ? { ...entry, args: append(entry.args) } : entry,
+	);
 }
 
 export function findLastIndex<T>(arr: readonly T[], predicate: (item: T) => boolean): number {

--- a/packages/desktop/src/renderer/src/stores/transcript-reducer/reducer.ts
+++ b/packages/desktop/src/renderer/src/stores/transcript-reducer/reducer.ts
@@ -15,6 +15,7 @@ import {
 	newToolKey,
 	parseArgs,
 	toolNameFromPartial,
+	updateThinkingActivity,
 	updateToolActivity,
 } from "./helpers";
 import type { CompactionUiState, SessionTranscriptState, SubagentRunUi, UIMessage } from "./types";
@@ -186,15 +187,15 @@ export function reduceEvent(state: SessionTranscriptState, event: SessionEvent):
 							textBlockIndex: streaming.textBlockIndex ?? e.contentIndex,
 						},
 					};
-				case "thinking_delta": {
-					// 活动序列：连续 thinking 合并为同一条目（内容从 streaming.thinking 读）
-					const last = streaming.activity[streaming.activity.length - 1];
-					const activity =
-						last?.kind === "thinking"
-							? streaming.activity
-							: [...streaming.activity, { id: "thinking", kind: "thinking" as const }];
-					return { ...state, streaming: { ...streaming, thinking: streaming.thinking + e.delta, activity } };
-				}
+				case "thinking_delta":
+					return {
+						...state,
+						streaming: {
+							...streaming,
+							thinking: streaming.thinking + e.delta,
+							activity: updateThinkingActivity(streaming.activity, e.contentIndex, (text) => text + e.delta),
+						},
+					};
 				case "toolcall_start": {
 					const name = toolNameFromPartial(e.partial, e.contentIndex);
 					const tools = [
@@ -259,8 +260,10 @@ export function reduceEvent(state: SessionTranscriptState, event: SessionEvent):
 						name: e.toolCall.name || tool.name,
 						args,
 					};
-					const activity = streaming.activity.map((a) =>
-						a.id === `c${e.contentIndex}` ? { ...a, name: e.toolCall.name || a.name, args } : a,
+					const activity = streaming.activity.map((entry) =>
+						entry.id === `c${e.contentIndex}` && entry.kind === "tool"
+							? { ...entry, name: e.toolCall.name || entry.name, args }
+							: entry,
 					);
 					return { ...state, streaming: { ...streaming, tools, activity, activeToolIndex: -1 } };
 				}

--- a/packages/desktop/src/renderer/src/stores/transcript-reducer/types.ts
+++ b/packages/desktop/src/renderer/src/stores/transcript-reducer/types.ts
@@ -94,16 +94,12 @@ export interface UIToolCall {
 	blockIndex?: number;
 }
 
-/** 预览活动条目：事件流按到达顺序追加，预览行永远显示最新一条（latest-wins） */
-export interface ActivityEntry {
-	/** 稳定身份：thinking 为 "thinking"，tool 为 `c${contentIndex}`（turn 内唯一，跨 delta/end 不变） */
-	id: string;
-	kind: "thinking" | "tool";
-	/** tool：工具名（toolcall_start 时已知） */
-	name?: string;
-	/** tool：参数摘要源文本（随 delta 增长，end 后为完整 JSON） */
-	args?: string;
-}
+/** 预览活动条目：事件流按首次到达顺序追加，只服务 live preview，不写入历史。 */
+export type ActivityEntry =
+	/** 按 content block 拆分，避免 think → tool → think 复用固定身份。 */
+	| { id: string; kind: "thinking"; text: string }
+	/** 工具参数随 delta 累积，toolcall_end 用最终规范参数覆盖。 */
+	| { id: string; kind: "tool"; name: string; args: string };
 
 /** 进行中的流式累积 */
 export interface StreamingState {

--- a/packages/desktop/src/renderer/src/stores/transcript.test.ts
+++ b/packages/desktop/src/renderer/src/stores/transcript.test.ts
@@ -127,6 +127,48 @@ describe("transcript reducer", () => {
 		expect(state.streaming?.text).toBe("Hello world");
 	});
 
+	it("thinking 活动按 contentIndex 累积并保持首次到达位置", () => {
+		let state = reduceEvent(emptyTranscript(), ev("agent_start"));
+		state = reduceEvent(state, {
+			type: "message_update",
+			assistantMessageEvent: { type: "thinking_delta", contentIndex: 0, delta: "先" },
+		} as unknown as AgentSessionEvent);
+		state = reduceEvent(state, {
+			type: "message_update",
+			assistantMessageEvent: { type: "thinking_delta", contentIndex: 0, delta: "想" },
+		} as unknown as AgentSessionEvent);
+		expect(state.streaming?.activity).toEqual([{ id: "h0", kind: "thinking", text: "先想" }]);
+	});
+
+	it("交错 thinking 与 tool 活动各自保留内容和到达顺序", () => {
+		let state = reduceEvent(emptyTranscript(), ev("agent_start"));
+		state = reduceEvent(state, {
+			type: "message_update",
+			assistantMessageEvent: { type: "thinking_delta", contentIndex: 0, delta: "第一段" },
+		} as unknown as AgentSessionEvent);
+		state = reduceEvent(state, {
+			type: "message_update",
+			assistantMessageEvent: {
+				type: "toolcall_start",
+				contentIndex: 1,
+				partial: { content: [{}, { type: "toolCall", name: "bash" }] },
+			},
+		} as unknown as AgentSessionEvent);
+		state = reduceEvent(state, {
+			type: "message_update",
+			assistantMessageEvent: { type: "toolcall_delta", contentIndex: 1, delta: '{"command":"ls"}' },
+		} as unknown as AgentSessionEvent);
+		state = reduceEvent(state, {
+			type: "message_update",
+			assistantMessageEvent: { type: "thinking_delta", contentIndex: 2, delta: "第二段" },
+		} as unknown as AgentSessionEvent);
+		expect(state.streaming?.activity).toEqual([
+			{ id: "h0", kind: "thinking", text: "第一段" },
+			{ id: "c1", kind: "tool", name: "bash", args: '{"command":"ls"}' },
+			{ id: "h2", kind: "thinking", text: "第二段" },
+		]);
+	});
+
 	it("turn_end 固化为 assistant 消息并回到 idle", () => {
 		let state = emptyTranscript();
 		state = reduceEvent(state, ev("agent_start"));


### PR DESCRIPTION
## 改进

工作中预览行（MetaGroup 溢出态）重写：让**最新 token 恒可见**。

- 新组件 `StreamingMarquee`：文本增长时右缘始终贴视口右缘（tail-follow），纯位移计算在 `marquee-motion.ts`（可单测），`prefers-reduced-motion` 下静态截断
- thinking 行从静态「思考中」标签改为显示流式正文
- tool 行工具名固定、参数原文横移（替代原 summarizeArgs 摘要截断）
- transcript-reducer：activity 条目携带累计 text（thinking 分块累计 / tool 原始参数累计），供 marquee 消费

## 验证

- [x] `npm run test` 全绿（marquee-motion 5 个新测试 + transcript 新增用例）
- [x] `npm run typecheck` / biome 全绿