### PR TITLE
chore(release): prepare 0.5.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11586,7 +11586,7 @@
 		},
 		"packages/desktop": {
 			"name": "@percho/desktop",
-			"version": "0.4.6",
+			"version": "0.5.0",
 			"license": "MIT",
 			"dependencies": {
 				"@dnd-kit/core": "^6.3.1",

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@percho/desktop",
-	"version": "0.4.6",
+	"version": "0.5.0",
 	"private": true,
 	"description": "Desktop GUI for the Pi coding agent",
 	"author": "Jaxton07",


### PR DESCRIPTION
Bumps `@percho/desktop` and its lockfile entry to 0.5.0. Local lint, typecheck, test, and `npm ci --dry-run` pass.