### PR TITLE
fix: ui.theme 契约实例 + Windows ui-plugins junction（#28）

### DIFF
--- a/packages/backend/src/session/ui-context.ts
+++ b/packages/backend/src/session/ui-context.ts
@@ -1,5 +1,78 @@
 import type { ExtensionUIContext } from "@earendil-works/pi-coding-agent";
+import { Theme } from "@earendil-works/pi-coding-agent";
 import type { PermissionGate } from "../permissions/gate";
+
+/**
+ * 提供给扩展的契约 Theme 实例（中性暗色盘，truecolor）。
+ *
+ * pi 扩展契约要求 ctx.ui.theme 是带 fg()/bg()/bold() 等方法的 Theme 对象（extensions.md
+ * 标准用法）；桌面端 GUI 无 TUI 状态栏，样式输出全部落到 no-op sink，但对象本身必须真
+ * （issue #28：pi-mcp-adapter 在 updateStatusBar 里 ui.theme.fg("accent", ...) 空对象/字符串
+ * 直接抛 TypeError，全部 MCP 服务器连接失败）。用真实 Theme 类实例保证全部 12+ 方法存在，
+ * 而非手写 pass-through 对象（进了一支扩展调用 italic()/getFgAnsi() 还是会崩）。
+ *
+ * 色盘为静态中性色：桌面端不消费 ANSI 输出，无需跟随 GUI 亮暗主题；构造参数受 TS 约束，
+ * SDK 升级新增必填色时 typecheck 会报错提醒补齐。Theme 构造纯内存计算，无环境依赖。
+ */
+const EXTENSION_THEME = new Theme(
+	{
+		accent: "#7aa2f7",
+		border: "#3b4261",
+		borderAccent: "#7aa2f7",
+		borderMuted: "#292e42",
+		success: "#9ece6a",
+		error: "#f7768e",
+		warning: "#e0af68",
+		muted: "#78849b",
+		dim: "#565f89",
+		text: "#c0caf5",
+		thinkingText: "#9d7cd8",
+		userMessageText: "#c0caf5",
+		customMessageText: "#c0caf5",
+		customMessageLabel: "#7aa2f7",
+		toolTitle: "#7dcfff",
+		toolOutput: "#a9b1d6",
+		mdHeading: "#7aa2f7",
+		mdLink: "#7dcfff",
+		mdLinkUrl: "#565f89",
+		mdCode: "#9ece6a",
+		mdCodeBlock: "#a9b1d6",
+		mdCodeBlockBorder: "#3b4261",
+		mdQuote: "#a9b1d6",
+		mdQuoteBorder: "#3b4261",
+		mdHr: "#3b4261",
+		mdListBullet: "#7dcfff",
+		toolDiffAdded: "#9ece6a",
+		toolDiffRemoved: "#f7768e",
+		toolDiffContext: "#565f89",
+		syntaxComment: "#565f89",
+		syntaxKeyword: "#bb9af7",
+		syntaxFunction: "#7aa2f7",
+		syntaxVariable: "#e0af68",
+		syntaxString: "#9ece6a",
+		syntaxNumber: "#ff9e64",
+		syntaxType: "#2ac3de",
+		syntaxOperator: "#89ddff",
+		syntaxPunctuation: "#c0caf5",
+		thinkingOff: "#565f89",
+		thinkingMinimal: "#6183bb",
+		thinkingLow: "#7aa2f7",
+		thinkingMedium: "#89ddff",
+		thinkingHigh: "#b4f9f8",
+		thinkingXhigh: "#d2e5ff",
+		bashMode: "#e0af68",
+	},
+	{
+		selectedBg: "#33467c",
+		userMessageBg: "#24283b",
+		customMessageBg: "#1f2335",
+		toolPendingBg: "#2f334d",
+		toolSuccessBg: "#20303b",
+		toolErrorBg: "#2d202a",
+	},
+	"truecolor",
+	{ name: "percho-desktop" },
+);
 
 /**
  * ExtensionUIContext 全量 no-op 实现：只桥接权限确认（confirm），其余保持默认。
@@ -31,7 +104,7 @@ export function makeUiContext(gate: PermissionGate): ExtensionUIContext {
 		addAutocompleteProvider: () => {},
 		setEditorComponent: () => {},
 		getEditorComponent: () => undefined,
-		theme: {} as ExtensionUIContext["theme"],
+		theme: EXTENSION_THEME,
 		getAllThemes: () => [],
 		getTheme: () => undefined,
 		setTheme: () => ({ success: true }),

--- a/packages/backend/test/ui-context.test.ts
+++ b/packages/backend/test/ui-context.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from "vitest";
+import type { PermissionGate } from "../src/permissions/gate";
+import { makeUiContext } from "../src/session/ui-context";
+
+/** issue #28 回归：ctx.ui.theme 必须是契约 Theme 对象（方法可调用），不能是空对象/字符串 */
+function fakeGate(): PermissionGate {
+	return { confirm: async () => false } as unknown as PermissionGate;
+}
+
+describe("makeUiContext — ui.theme 契约", () => {
+	it("theme 是对象且 fg/bg/bold 等样式方法全部可调用并返回字符串", () => {
+		const ui = makeUiContext(fakeGate());
+		// pi-mcp-adapter init.ts updateStatusBar 的实际用法：ui.theme ? theme.fg(...) : ...
+		// 空对象/字符串会让 truthy 判断走进 .fg() 分支抛 TypeError（全部 MCP 服务器连接失败）
+		expect(typeof ui.theme).toBe("object");
+		expect(ui.theme).not.toBeNull();
+
+		expect(ui.theme.fg("accent", "mcp: ready")).toContain("mcp: ready");
+		expect(ui.theme.bg("selectedBg", "x")).toContain("x");
+		expect(ui.theme.bold("x")).toContain("x");
+		// 其余 Theme 方法也要存在（扩展可能调用任何一个；手写 pass-through 对象漏一个就崩）
+		expect(ui.theme.italic("x")).toContain("x");
+		expect(ui.theme.underline("x")).toContain("x");
+		expect(ui.theme.inverse("x")).toContain("x");
+		expect(ui.theme.strikethrough("x")).toContain("x");
+		expect(typeof ui.theme.getFgAnsi("accent")).toBe("string");
+		expect(typeof ui.theme.getBgAnsi("selectedBg")).toBe("string");
+		expect(ui.theme.getColorMode()).toMatch(/truecolor|256color/);
+		expect(typeof ui.theme.getThinkingBorderColor("high")).toBe("function");
+	});
+
+	it("所有 ThemeColor 枚举值都能被 fg() 接受（色表完整，不会运行时缺色）", () => {
+		const ui = makeUiContext(fakeGate());
+		const colors = [
+			"accent",
+			"border",
+			"borderAccent",
+			"borderMuted",
+			"success",
+			"error",
+			"warning",
+			"muted",
+			"dim",
+			"text",
+			"thinkingText",
+			"userMessageText",
+			"customMessageText",
+			"customMessageLabel",
+			"toolTitle",
+			"toolOutput",
+			"mdHeading",
+			"mdLink",
+			"mdLinkUrl",
+			"mdCode",
+			"mdCodeBlock",
+			"mdCodeBlockBorder",
+			"mdQuote",
+			"mdQuoteBorder",
+			"mdHr",
+			"mdListBullet",
+			"toolDiffAdded",
+			"toolDiffRemoved",
+			"toolDiffContext",
+			"syntaxComment",
+			"syntaxKeyword",
+			"syntaxFunction",
+			"syntaxVariable",
+			"syntaxString",
+			"syntaxNumber",
+			"syntaxType",
+			"syntaxOperator",
+			"syntaxPunctuation",
+			"thinkingOff",
+			"thinkingMinimal",
+			"thinkingLow",
+			"thinkingMedium",
+			"thinkingHigh",
+			"thinkingXhigh",
+			"bashMode",
+		] as const;
+		for (const color of colors) {
+			expect(ui.theme.fg(color, "t")).toContain("t");
+		}
+	});
+});

--- a/packages/desktop/src/main/ui-plugins/manager.ts
+++ b/packages/desktop/src/main/ui-plugins/manager.ts
@@ -120,10 +120,15 @@ async function seedDocs(): Promise<void> {
 			log.warn("~/.percho/ui-plugins 已存在且非 symlink，跳过");
 		} else {
 			await mkdir(join(homedir(), ".percho"), { recursive: true });
-			await symlink(root, link);
+			// Windows 普通用户建符号链接需管理员/开发者模式（EPERM 必现，#28 附报）；
+			// junction 目录联接不需提权，行为等价（目录型链接、跟随重定向）；
+			// 其他平台保持真 symlink（lstat/realpath 判定与上面一致，junction 在 POSIX 不可用）
+			await symlink(root, link, process.platform === "win32" ? "junction" : undefined);
 		}
 	} catch (err) {
-		log.error("symlink ~/.percho/ui-plugins failed", err);
+		// 链接失败只告警：插件功能不受影响（真实目录在 userData/ui-plugins），
+		// 只是 agent 按规范路径 ~/.percho/ui-plugins 读不到，提示真实路径便于排查
+		log.error(`symlink ~/.percho/ui-plugins failed（真实插件目录：${root}）`, err);
 	}
 }
 


### PR DESCRIPTION
修复 #28（主要问题）及其附报的 Windows symlink 问题。

## 1. ui.theme 提供契约 Theme 实例（#28 主问题）

**问题**：`makeUiContext` 给扩展的 `ctx.ui.theme` 是空对象强转（`{} as ExtensionUIContext["theme"]`），而 pi 扩展契约要求带 `fg()/bg()/bold()` 等方法的 **Theme 对象**。任何 `theme.fg(...)` 调用抛 `TypeError`——pi-mcp-adapter 的 `updateStatusBar()` 因此崩溃，异常被 adapter 自己的 catch 转成连接失败，**所有 MCP 服务器永久 not-connected**。其他用 theme 的扩展 API（`setStatus`/`setWidget`/`setFooter`/`setWorkingIndicator`/`registerEntryRenderer`）同隐患。

**修复**：模块级 `EXTENSION_THEME = new Theme(完整色表, bg表, "truecolor")`，用真实类实例而非手写 pass-through 对象——Theme 有 12+ 方法（`italic`/`underline`/`inverse`/`getFgAnsi`/`getThinkingBorderColor`…），手写对象漏一个扩展还是会崩。

设计取舍：
- 桌面端样式输出全落 no-op sink，不消费 ANSI → 静态中性暗色盘，无需跟随 GUI 亮暗主题
- 色表构造受 TS 约束：SDK 升级新增必填色时 typecheck 报错提醒
- 选包根导出的 `Theme` 类直构，而非深路径 `getThemeByName`（包 exports map 封死深路径，且 JSON 读取在 asar 里更脆）

## 2. Windows 下 ui-plugins 稳定路径降级 junction（#28 附报）

**问题**：Windows 普通用户创建符号链接需要管理员权限或开发者模式，`seedDocs()` 的 `symlink` 每次启动必抛 `EPERM`，`~/.percho/ui-plugins` 永远建不上——agent 按规范路径读 SPEC/`_examples` 的通道断掉。

**修复**：Windows 传 `"junction"` 类型（目录联接不需提权，`realpath` 正常解析，下次启动的 lstat/realpath 判定不受影响）；其他平台保持真 symlink。链接失败日志带上真实插件目录路径。

## 测试

`test/ui-context.test.ts` 契约回归：全部样式方法可调用返回字符串 + 全部 45 个 ThemeColor 枚举值 `fg()` 不缺色。

## 关联

- Closes #28
- 可观测性缺口（扩展异常宿主日志零线索）已单开 #32