### PR TITLE
chore(release): follow-ups for Linux AppImage support (#46)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,3 +23,13 @@ jobs:
       - run: npm run typecheck
       - run: npm run test
       - run: npm run build
+      # 打包冒烟：只解包不出安装器（--dir，此时 electron-builder 不做 publish），
+      # 让打包层回归（electron-builder.yml 解析、files/asarUnpack glob、图标、原生模块 unpack）
+      # 在 PR 阶段暴露，而不是发版打 tag 时才爆。Electron 二进制走缓存。
+      - uses: actions/cache@v4
+        with:
+          path: ~/.cache/electron
+          key: electron-${{ runner.os }}-${{ hashFiles('packages/desktop/package.json') }}
+      - name: Packaging smoke (electron-builder --dir)
+        working-directory: packages/desktop
+        run: npx electron-builder --dir

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,6 +34,8 @@ jobs:
             !packages/desktop/dist/mac-arm64
             !packages/desktop/dist/win-unpacked
             !packages/desktop/dist/linux-unpacked
+            # electron-builder 每次构建都会写入的诊断文件，不足发布产物
+            !packages/desktop/dist/builder-debug.yml
           if-no-files-found: error
   publish:
     needs: build
@@ -58,7 +60,7 @@ jobs:
           | Windows | `percho-windows-x64.exe` (installer) or `percho-windows-x64.zip` |
           | Linux (x64) | `percho-linux-x86_64.AppImage` |
 
-          > Ad-hoc signed (no Developer ID). On macOS, if Gatekeeper blocks the app, right-click it and choose **Open** (or run `xattr -cr "/Applications/Percho.app"`). Windows builds update automatically in-app.
+          > Ad-hoc signed (no Developer ID). On macOS, if Gatekeeper blocks the app, right-click it and choose **Open** (or run `xattr -cr "/Applications/Percho.app"`). Windows and Linux builds update automatically in-app. On Linux, `chmod +x` the AppImage before first launch (and install `libfuse2` on Ubuntu 22.04+/24.04+ if it won't start).
           EOF
   # 刷新官网（percho-website，Cloudflare Pages）：触发 Deploy Hook 重建，同步版本号与 changelog。
   # 需要 repo secret CF_PAGES_DEPLOY_HOOK（Cloudflare Pages → Settings → Builds → Deploy hooks 创建）；未配置时跳过不影响发布

--- a/README.md
+++ b/README.md
@@ -80,6 +80,8 @@ Prebuilt installers are published on the [Releases](https://github.com/Jaxton07/
 > 2. Or in Terminal: `xattr -cr "/Applications/Percho.app"`.
 >
 > Updates are checked in-app. On Windows they download and install there too (click download, then restart). On macOS the ad-hoc signed build cannot self-install, so the app jumps to the Releases page — and a freshly downloaded version will hit Gatekeeper once again. On Windows, click "More info" → "Run anyway" when SmartScreen appears.
+>
+> On Linux: make the AppImage executable before first launch (`chmod +x percho-linux-x86_64.AppImage`). On Ubuntu 22.04+/24.04+ and derivatives, install `libfuse2` first — AppImages mount via FUSE 2, which is no longer preinstalled. Linux builds download and install updates in-app.
 
 ## Configuration
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -81,6 +81,8 @@ percho 把官方 Pi SDK（`@earendil-works/pi-coding-agent`）跑在 Electron �
 > 2. 或在终端执行：`xattr -cr "/Applications/Percho.app"`。
 >
 > 更新在应用内检查。Windows 上也在应用内下载安装（点下载，再点重启）；macOS 上 adhoc 签名的构建无法自动安装，点击会跳到 Releases 页 —— 新下载的版本首次打开还会再被 Gatekeeper 拦一次。Windows 上 SmartScreen 提示时点「更多信息」→「仍要运行」。
+>
+> Linux：首次运行前给 AppImage 加执行位（`chmod +x percho-linux-x86_64.AppImage`）；Ubuntu 22.04+/24.04+ 及衍生发行版需先安装 `libfuse2`（AppImage 依赖 FUSE 2 挂载，新版系统默认未装）。Linux 版在应用内下载并安装更新。
 
 ## 配置
 

--- a/docs/PITFALLS.md
+++ b/docs/PITFALLS.md
@@ -17,6 +17,7 @@
 | main 进程 import workspace 包行为异常（外部化/旧产物） | 三 · externalizeDepsPlugin |
 | 打包产物缺 pi SDK、Electron 版本漂移 | 三 · 打包两个坑 |
 | Electron 二进制下载不动、npm 拦 postinstall | 三 · Node/npm 环境 |
+| gh 合并报 workflow scope / fork 首 PR 合不了 | 三 · gh CLI workflow scope |
 | 新增 UI 文案只显示一种语言 | 四 · i18n 双字典 |
 | 凭证泄漏风险、密钥误提交 | 五 · 绝不打印/提交 API key |
 | LAN 页连接僵死不重连、状态「重连中/已连接」反复跳 | 二 · SSE 心跳必须是命名事件帧 |
@@ -112,6 +113,12 @@ main config 用 `exclude: ["@percho/backend", "@percho/shared"]` 并 alias 到�
 ### 打包两个坑
 
 pi SDK 必须声明进 `packages/desktop/package.json` dependencies（electron-builder 只从 desktop 依赖树收集）；electron 必须钉精确版本。发版/CI 细节全在 `.local/docs/release.md`（本地文档，不入库）。
+
+### gh CLI 合并涉及 workflow 的 PR 需要 `workflow` scope（2026-09-11 发现）
+
+`gh pr merge --squash` 报 `refusing to allow an OAuth App to create or update workflow .github/workflows/xxx.yml without workflow scope`：gh 的 OAuth token 默认只有 `repo/gist/read:org`，而**凡 merge 会改动 `.github/workflows/` 下文件的 PR，GitHub API 一律要求 `workflow` scope**。修复：`gh auth refresh -h github.com -s workflow`（设备码流程，浏览器确认，一次性）；或网页 UI 手动合。
+
+连带坑（首贡献者 fork PR 死锁）：fork 首次 PR 的 CI 要在 Actions 页面手动 Approve 才会跑，叠加分支保护「要求 branch up-to-date + 检查通过」→ 三者互等死锁，只能 admin 旁路（`gh pr merge --squash --admin`，同样吃上面的 scope 限制）。同步 fork 分支用 `gh pr update-branch <n>`。
 
 ## 四、Renderer / React
 


### PR DESCRIPTION
## Summary

Follow-ups for the items called out during the #46 review (see [review comment](https://github.com/Jaxton07/percho/pull/46#issuecomment-5628104731)):

1. **Docs** (`README.md` / `README.zh.md`): Linux runtime prerequisites — `chmod +x` the AppImage before first launch, `libfuse2` needed on Ubuntu 22.04+/24.04+ (FUSE 2 is no longer preinstalled), plus a note that Linux builds auto-update in-app
2. **Release workflow**:
   - exclude `builder-debug.yml` from release assets (pre-existing wart — electron-builder's per-build diagnostic file has been published in every release so far)
   - release-notes footnote now covers Linux (in-app updates + first-launch prerequisites)
3. **CI** (`ci.yml`): packaging smoke — `electron-builder --dir` on ubuntu with the electron zip cached, so packaging-layer regressions (electron-builder.yml parsing, files/asarUnpack globs, icons, native module unpacking) surface at PR time instead of release-tag time. Verified locally on macOS (`--dir` builds clean with the new `linux:` section present)

## Deferred

- Ubuntu 24.04 sandbox verification (Chromium sandbox vs `kernel.apparmor_restrict_unprivileged_userns` restriction) — needs a machine; if it reproduces we'll document the sysctl workaround next to the Linux note in the READMEs
