### PR TITLE
chore(release): v0.5.7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11659,7 +11659,7 @@
 		},
 		"packages/desktop": {
 			"name": "@percho/desktop",
-			"version": "0.5.6",
+			"version": "0.5.7",
 			"license": "MIT",
 			"dependencies": {
 				"@dnd-kit/core": "^6.3.1",

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@percho/desktop",
-	"version": "0.5.6",
+	"version": "0.5.7",
 	"private": true,
 	"description": "Desktop GUI for the Pi coding agent",
 	"author": "Jaxton07",


### PR DESCRIPTION
## What does this PR do?

Prepares the **v0.5.7** release: bumps `@percho/desktop` 0.5.6 → 0.5.7（`package.json` + `package-lock.json` 同源，避免上次 0.5.5 那种 lock 漏更）。tag `v0.5.7` 由本分支合并后单独打，触发 Release workflow（mac arm64/x64 + win x64 + linux x64 AppImage）。

本版内容（等待发布的 commit 区间 `v0.5.6..main`）：

- perf(chat)：长会话切会话卡顿修复——消息流挂载窗口 + 工具卡布局测量合并 (#53)
- feat(subagent)：思考深度支持 + 执行器切换开关 (#47)
- feat(extensions)：扩展交互 GUI 适配——对话框四件套 + notify Toast (#49 / #45)
- feat(ui-plugins)：opencode-go quota hook (`useQuota`) + `composer.footer` region (#51)
- feat(build)：Linux AppImage target + 发布链路 (#46)，及补遗 (#52)
- fix(ui)：流式正文/代码块渲染稳定、会话动作失败改走 toast

## How was it tested?

- 版本号与 lock 一致性：`npm ls @percho/desktop` → `0.5.7`
- CI：lint / typecheck / test / build / electron-builder `--dir` 打包冒烟全绿即可合并（tag 前的最后一次门禁）

## Checklist

- [x] `npm run lint` passes
- [x] `npm run typecheck` passes
- [x] `npm run test` passes
- [x] New user-facing strings were added to both `zh` and `en` dictionaries — N/A（仅版本号）
- [x] No API keys or sensitive data included