### PR TITLE
chore(release): v0.5.8

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11659,7 +11659,7 @@
 		},
 		"packages/desktop": {
 			"name": "@percho/desktop",
-			"version": "0.5.7",
+			"version": "0.5.8",
 			"license": "MIT",
 			"dependencies": {
 				"@dnd-kit/core": "^6.3.1",

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@percho/desktop",
-	"version": "0.5.7",
+	"version": "0.5.8",
 	"private": true,
 	"description": "Desktop GUI for the Pi coding agent",
 	"author": "Jaxton07",


### PR DESCRIPTION
## What does this PR do?

Prepares the **v0.5.8** hotfix release: bumps `@percho/desktop` 0.5.7 → 0.5.8（`package.json` + `package-lock.json` 同源）。tag `v0.5.8` 由本分支合并后单独打，触发 Release workflow（mac arm64/x64 + win x64 + linux x64 AppImage）。

本版内容（`v0.5.7..main`，只有一条）：

- fix(chat)：长会话上滑被反复拽回底部——滚动锚定交回浏览器 (#56) —— 修 0.5.7 引入的回归：切进长会话后上滚，视口被反复拽回底部（markstream 内容异步定型缩水 + 手写滚动补偿只看提交时刻 + 到位即复活跟随）。

## How was it tested?

- 补丁本身已在 #56 验过：真实轮事件上滚 55 步的「视口顶行序号单调不降」不变量，旧实现 11 次违规 → 0 次；切换耗时无回归（175.7ms vs 176.7ms）；lint(0 warning) / typecheck / test(340) / build 全绿
- 版本号与 lock 一致性：`npm ls @percho/desktop` → `0.5.8`
- CI（lint / typecheck / test / build / electron-builder `--dir` 打包冒烟）全绿即可合并，随后打 tag

## Checklist

- [x] `npm run lint` passes
- [x] `npm run typecheck` passes
- [x] `npm run test` passes
- [x] New user-facing strings were added to both `zh` and `en` dictionaries — N/A（仅版本号）
- [x] No API keys or sensitive data included